### PR TITLE
fix(server): validate user localpart to prevent path traversal

### DIFF
--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -15,10 +15,36 @@ logger = logging.getLogger(__name__)
 
 _start_time = time.monotonic()
 _AS_TOKEN_RE = re.compile(r"^(.+)_as_token\.txt$")
+_VALID_LOCALPART_RE = re.compile(r"^[a-z0-9._\-]+$")
+
+
+def _validate_user_localpart(user: str, handler: BaseHTTPRequestHandler) -> bool:
+    """
+    Validate that user is a valid Matrix localpart to prevent path traversal.
+
+    Returns True if valid, False otherwise. If invalid, sends 400 response.
+    """
+    if not _VALID_LOCALPART_RE.match(user):
+        logger.warning(
+            f"Invalid user localpart '{user}' from {handler.client_address}. "
+            f"Must match [a-z0-9._-]+"
+        )
+        handler.send_response(400)
+        handler.send_header("Content-Type", "text/plain")
+        handler.end_headers()
+        handler.wfile.write(b"Invalid user parameter. Must match [a-z0-9._-]+")
+        return False
+    return True
 
 
 def _pre_flight_check(config: Config) -> None:
     logger.info("Performing pre-flight check...")
+
+    if not _VALID_LOCALPART_RE.match(config.default_user):
+        raise RuntimeError(
+            f"Invalid default_user '{config.default_user}'. "
+            f"Must match [a-z0-9._-]+ to prevent path traversal."
+        )
 
     default_user_token_path = _token_path(config.default_user)
     if not os.path.isfile(default_user_token_path):
@@ -82,6 +108,10 @@ def _make_handler(config: Config) -> type:
             params = parse_qs(parsed.query)
             service = params.get("service", [None])[0]
             user = params.get("user", [None])[0] or service or config.default_user
+
+            if not _validate_user_localpart(user, self):
+                return
+
             format_fn = SERVICES.get(service, format_generic)
             user_id = f"@{user}:{config.domain}"
 

--- a/tests/test_user_validation.py
+++ b/tests/test_user_validation.py
@@ -1,0 +1,125 @@
+"""Tests for user parameter validation to prevent path traversal."""
+
+import pytest
+
+from matrix_webhook_bridge.config import Config
+from matrix_webhook_bridge.server import _pre_flight_check, _validate_user_localpart
+
+
+class _FakeHandler:
+    """Minimal mock HTTP handler for testing validation."""
+
+    def __init__(self):
+        self.client_address = ("127.0.0.1", 12345)
+        self.response_code = None
+        self.headers_sent = []
+        self.response_body = b""
+
+    def send_response(self, code: int) -> None:
+        self.response_code = code
+
+    def send_header(self, key: str, value: str) -> None:
+        self.headers_sent.append((key, value))
+
+    def end_headers(self) -> None:
+        pass
+
+    class wfile:
+        @staticmethod
+        def write(data: bytes) -> None:
+            pass
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        "bridge",
+        "alertmanager",
+        "crowdsec",
+        "borgmatic",
+        "user123",
+        "my-user",
+        "my_user",
+        "my.user",
+        "a",
+        "user-with-many-parts",
+        "user_123.test-name",
+    ],
+)
+def test_validate_user_localpart_accepts_valid_users(user):
+    """Valid Matrix localparts should pass validation."""
+    handler = _FakeHandler()
+    assert _validate_user_localpart(user, handler) is True
+    assert handler.response_code is None
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        "../secret",
+        "../../etc/passwd",
+        "/etc/passwd",
+        "../",
+        "./",
+        "user/path",
+        "user\\path",
+        "user with spaces",
+        "UPPERCASE",
+        "User",
+        "user@domain",
+        "user:domain",
+        "user;cmd",
+        "user|cmd",
+        "user&cmd",
+        "user$var",
+        "user`cmd`",
+        "user'cmd'",
+        'user"cmd"',
+        "user<cmd>",
+        "user{cmd}",
+        "user[cmd]",
+        "",
+    ],
+)
+def test_validate_user_localpart_rejects_invalid_users(user):
+    """Invalid or malicious user parameters should be rejected."""
+    handler = _FakeHandler()
+    assert _validate_user_localpart(user, handler) is False
+    assert handler.response_code == 400
+
+
+@pytest.fixture
+def secrets_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_pre_flight_check_validates_default_user(secrets_dir):
+    """Pre-flight check should reject invalid default_user to prevent path traversal."""
+    (secrets_dir / "../secret_as_token.txt").write_text("tok")
+
+    config = Config(
+        base_url="https://matrix.example.com",
+        room_id="!room:example.com",
+        domain="example.com",
+        default_user="../secret",
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid default_user"):
+        _pre_flight_check(config)
+
+
+def test_pre_flight_check_accepts_valid_default_user(secrets_dir):
+    """Pre-flight check should accept valid default_user."""
+    (secrets_dir / "bridge_as_token.txt").write_text("tok")
+
+    config = Config(
+        base_url="https://matrix.example.com",
+        room_id="!room:example.com",
+        domain="example.com",
+        default_user="bridge",
+    )
+
+    # Should not raise
+    _pre_flight_check(config)


### PR DESCRIPTION
Validates user query parameter against Matrix localpart charset to prevent path traversal attacks.

Fixes #30