### PR TITLE
fix(docker): install wget for healthcheck probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,11 @@ LABEL org.opencontainers.image.source="https://github.com/krahlos/matrix-webhook
 LABEL org.opencontainers.image.description="Webhook-to-Matrix notification bridge with per-sender bot users"
 LABEL maintainer="${MAINTAINER}"
 
+# wget is needed for the HEALTHCHECK probe
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends wget \
+ && rm -rf /var/lib/apt/lists/*
+
 # Dedicated non-root user
 RUN addgroup --gid 1001 --system bridge \
  && adduser  --uid 1001 --system --ingroup bridge --no-create-home bridge
@@ -41,6 +46,6 @@ USER bridge
 EXPOSE 5001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD ["matrix-webhook-bridge", "healthcheck"]
+    CMD wget --spider -q http://localhost:5001/healthy || exit 1
 
 CMD ["matrix-webhook-bridge", "serve", "--config", "/etc/matrix-webhook-bridge/config.yml"]


### PR DESCRIPTION
- Install `wget` in the runtime Docker image so the `HEALTHCHECK` probe can reach `/healthy`
- Switch the `HEALTHCHECK` instruction from the Python CLI to a direct `wget --spider` call for faster, lighter probes

Closes #44