### PR TITLE
feat: resolve sender from config service_users instead of ?user= param

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,25 @@ Any HTTP client can post to `/notify`:
 
 ```sh
 # generic message
-curl -X POST "http://localhost:5001/notify?user=bridge" \
+curl -X POST "http://localhost:5001/notify" \
      -H "Content-Type: application/json" \
      -d '{"body": "Hello from the bridge!"}'
 
-# with HTML formatting
-curl -X POST "http://localhost:5001/notify?user=bridge" \
+# with a registered service formatter
+curl -X POST "http://localhost:5001/notify?service=alertmanager" \
      -H "Content-Type: application/json" \
      -d '{"body": "plain text", "html": "<b>bold text</b>"}'
 ```
 
 ### Query parameters
 
-| Parameter | Description                                                          |
-| --------- | -------------------------------------------------------------------- |
-| `user`    | Matrix user localpart to impersonate (e.g. `bridge`)                 |
-| `service` | Activates a built-in formatter; also sets the user if not specified  |
+| Parameter | Description                                                                            |
+| --------- | -------------------------------------------------------------------------------------- |
+| `service` | Activates a built-in formatter and selects the sender via `service_users` in config    |
+
+The sender (Matrix user localpart and token) is determined server-side: the `service_users` map
+in `bridge.yml` maps each service name to its user localpart. If the service is not listed,
+`default_user` is used.
 
 ## Built-in formatters
 

--- a/bridge.yml.example
+++ b/bridge.yml.example
@@ -25,3 +25,10 @@ server:
   # When set, all POST requests must include an Authorization header:
   #   Authorization: Bearer <webhook_secret>
   # webhook_secret: your-secret-here
+
+  # Map each ?service= value to the Matrix user localpart that should send the message.
+  # If a service is not listed here, default_user is used.
+  # service_users:
+  #   alertmanager: alertmanager
+  #   borgmatic: borgmatic
+  #   crowdsec: crowdsec

--- a/matrix_webhook_bridge/config.py
+++ b/matrix_webhook_bridge/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -10,3 +10,4 @@ class Config:
     default_user: str = "bridge"
     matrix_timeout: int = 5
     webhook_secret: str | None = None
+    service_users: dict[str, str] = field(default_factory=dict)

--- a/matrix_webhook_bridge/config_loader.py
+++ b/matrix_webhook_bridge/config_loader.py
@@ -61,6 +61,11 @@ CONFIG_SCHEMA = {
                     "minLength": 1,
                     "description": "Shared secret for incoming webhook authentication",
                 },
+                "service_users": {
+                    "type": "object",
+                    "additionalProperties": {"type": "string", "minLength": 1},
+                    "description": "Map of service name to Matrix user localpart",
+                },
             },
             "additionalProperties": False,
         },
@@ -121,4 +126,5 @@ def load_config_from_yaml(path: str) -> Config:
         port=server_section.get("port", 5001),
         default_user=server_section.get("default_user", "bridge"),
         webhook_secret=server_section.get("webhook_secret"),
+        service_users=server_section.get("service_users", {}),
     )

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -19,25 +19,6 @@ _AS_TOKEN_RE = re.compile(r"^(.+)_as_token\.txt$")
 _VALID_LOCALPART_RE = re.compile(r"^[a-z0-9._\-]+$")
 
 
-def _validate_user_localpart(user: str, handler: BaseHTTPRequestHandler) -> bool:
-    """
-    Validate that user is a valid Matrix localpart to prevent path traversal.
-
-    Returns True if valid, False otherwise. If invalid, sends 400 response.
-    """
-    if not _VALID_LOCALPART_RE.match(user):
-        logger.warning(
-            f"Invalid user localpart '{user}' from {handler.client_address}. "
-            f"Must match [a-z0-9._-]+"
-        )
-        handler.send_response(400)
-        handler.send_header("Content-Type", "text/plain")
-        handler.end_headers()
-        handler.wfile.write(b"Invalid user parameter. Must match [a-z0-9._-]+")
-        return False
-    return True
-
-
 def _pre_flight_check(config: Config) -> None:
     logger.info("Performing pre-flight check...")
 
@@ -46,6 +27,13 @@ def _pre_flight_check(config: Config) -> None:
             f"Invalid default_user '{config.default_user}'. "
             f"Must match [a-z0-9._-]+ to prevent path traversal."
         )
+
+    for svc, user in config.service_users.items():
+        if not _VALID_LOCALPART_RE.match(user):
+            raise RuntimeError(
+                f"Invalid user '{user}' for service '{svc}' in service_users. "
+                f"Must match [a-z0-9._-]+ to prevent path traversal."
+            )
 
     default_user_token_path = _token_path(config.default_user)
     if not os.path.isfile(default_user_token_path):
@@ -126,10 +114,8 @@ def _make_handler(config: Config) -> type:
 
             params = parse_qs(parsed.query)
             service = params.get("service", [None])[0]
-            user = params.get("user", [None])[0] or service or config.default_user
-
-            if not _validate_user_localpart(user, self):
-                return
+            user = config.service_users.get(service) if service else None
+            user = user or config.default_user
 
             format_fn = SERVICES.get(service, format_generic)
             user_id = f"@{user}:{config.domain}"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -309,6 +309,51 @@ matrix:
         Path(config_path).unlink()
 
 
+def test_load_config_with_service_users():
+    """service_users mapping is loaded when present."""
+    yaml_content = """
+matrix:
+  base_url: https://matrix.example.com
+  room_id: "!test:example.com"
+  domain: example.com
+
+server:
+  service_users:
+    alertmanager: alertmanager
+    borgmatic: borgmatic
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        config_path = f.name
+
+    try:
+        config = load_config_from_yaml(config_path)
+        assert config.service_users == {"alertmanager": "alertmanager", "borgmatic": "borgmatic"}
+    finally:
+        Path(config_path).unlink()
+
+
+def test_load_config_service_users_defaults_to_empty():
+    """service_users defaults to empty dict when omitted."""
+    yaml_content = """
+matrix:
+  base_url: https://matrix.example.com
+  room_id: "!test:example.com"
+  domain: example.com
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        config_path = f.name
+
+    try:
+        config = load_config_from_yaml(config_path)
+        assert config.service_users == {}
+    finally:
+        Path(config_path).unlink()
+
+
 def test_load_config_empty_file():
     """ConfigError raised when YAML file is empty."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:

--- a/tests/test_user_validation.py
+++ b/tests/test_user_validation.py
@@ -1,91 +1,9 @@
-"""Tests for user parameter validation to prevent path traversal."""
+"""Tests for user localpart validation in pre-flight checks."""
 
 import pytest
 
 from matrix_webhook_bridge.config import Config
-from matrix_webhook_bridge.server import _pre_flight_check, _validate_user_localpart
-
-
-class _FakeHandler:
-    """Minimal mock HTTP handler for testing validation."""
-
-    def __init__(self):
-        self.client_address = ("127.0.0.1", 12345)
-        self.response_code = None
-        self.headers_sent = []
-        self.response_body = b""
-
-    def send_response(self, code: int) -> None:
-        self.response_code = code
-
-    def send_header(self, key: str, value: str) -> None:
-        self.headers_sent.append((key, value))
-
-    def end_headers(self) -> None:
-        pass
-
-    class wfile:
-        @staticmethod
-        def write(data: bytes) -> None:
-            pass
-
-
-@pytest.mark.parametrize(
-    "user",
-    [
-        "bridge",
-        "alertmanager",
-        "crowdsec",
-        "borgmatic",
-        "user123",
-        "my-user",
-        "my_user",
-        "my.user",
-        "a",
-        "user-with-many-parts",
-        "user_123.test-name",
-    ],
-)
-def test_validate_user_localpart_accepts_valid_users(user):
-    """Valid Matrix localparts should pass validation."""
-    handler = _FakeHandler()
-    assert _validate_user_localpart(user, handler) is True
-    assert handler.response_code is None
-
-
-@pytest.mark.parametrize(
-    "user",
-    [
-        "../secret",
-        "../../etc/passwd",
-        "/etc/passwd",
-        "../",
-        "./",
-        "user/path",
-        "user\\path",
-        "user with spaces",
-        "UPPERCASE",
-        "User",
-        "user@domain",
-        "user:domain",
-        "user;cmd",
-        "user|cmd",
-        "user&cmd",
-        "user$var",
-        "user`cmd`",
-        "user'cmd'",
-        'user"cmd"',
-        "user<cmd>",
-        "user{cmd}",
-        "user[cmd]",
-        "",
-    ],
-)
-def test_validate_user_localpart_rejects_invalid_users(user):
-    """Invalid or malicious user parameters should be rejected."""
-    handler = _FakeHandler()
-    assert _validate_user_localpart(user, handler) is False
-    assert handler.response_code == 400
+from matrix_webhook_bridge.server import _pre_flight_check
 
 
 @pytest.fixture
@@ -95,17 +13,18 @@ def secrets_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-def test_pre_flight_check_validates_default_user(secrets_dir):
-    """Pre-flight check should reject invalid default_user to prevent path traversal."""
-    (secrets_dir / "../secret_as_token.txt").write_text("tok")
-
-    config = Config(
+def _base_config(**kwargs) -> Config:
+    return Config(
         base_url="https://matrix.example.com",
         room_id="!room:example.com",
         domain="example.com",
-        default_user="../secret",
+        **kwargs,
     )
 
+
+def test_pre_flight_check_validates_default_user(secrets_dir):
+    """Pre-flight check should reject invalid default_user to prevent path traversal."""
+    config = _base_config(default_user="../secret")
     with pytest.raises(RuntimeError, match="Invalid default_user"):
         _pre_flight_check(config)
 
@@ -113,13 +32,44 @@ def test_pre_flight_check_validates_default_user(secrets_dir):
 def test_pre_flight_check_accepts_valid_default_user(secrets_dir):
     """Pre-flight check should accept valid default_user."""
     (secrets_dir / "bridge_as_token.txt").write_text("tok")
+    config = _base_config(default_user="bridge")
+    _pre_flight_check(config)
 
-    config = Config(
-        base_url="https://matrix.example.com",
-        room_id="!room:example.com",
-        domain="example.com",
-        default_user="bridge",
-    )
 
-    # Should not raise
+@pytest.mark.parametrize(
+    "user",
+    [
+        "../secret",
+        "../../etc/passwd",
+        "/etc/passwd",
+        "user/path",
+        "user with spaces",
+        "UPPERCASE",
+        "user@domain",
+    ],
+)
+def test_pre_flight_rejects_invalid_service_user(secrets_dir, user):
+    """Pre-flight check should reject invalid service_users localparts."""
+    (secrets_dir / "bridge_as_token.txt").write_text("tok")
+    config = _base_config(service_users={"mysvc": user})
+    with pytest.raises(RuntimeError, match="Invalid user"):
+        _pre_flight_check(config)
+
+
+@pytest.mark.parametrize(
+    "user",
+    [
+        "alertmanager",
+        "borgmatic",
+        "crowdsec",
+        "my-bot",
+        "my_bot",
+        "my.bot",
+        "bot123",
+    ],
+)
+def test_pre_flight_accepts_valid_service_users(secrets_dir, user):
+    """Pre-flight check should accept valid service_users localparts."""
+    (secrets_dir / "bridge_as_token.txt").write_text("tok")
+    config = _base_config(service_users={"mysvc": user})
     _pre_flight_check(config)


### PR DESCRIPTION
The `?user=` query parameter previously let callers pick which Matrix user (and token) to send as. This moves that decision server-side. Closes #13.