### PR TITLE
ci: add prerelease flag to release dispatch

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -10,6 +10,11 @@ on:
         description: "Version to release (vX.Y.Z)"
         required: true
         type: string
+      prerelease:
+        description: "Mark as pre-release"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -133,4 +138,5 @@ jobs:
               tag_name: '${{ inputs.version }}',
               name: '${{ inputs.version }}',
               generate_release_notes: true,
+              prerelease: ${{ inputs.prerelease }},
             });


### PR DESCRIPTION
Adds an optional boolean input to the release workflow. Defaults to false so existing dispatches are unaffected.