### PR TITLE
refactor: replace ThreadingHTTPServer with FastAPI + uvicorn

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: pip install pytest .
+        run: pip install ".[test]"
 
       - name: Run tests
         run: pytest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: pip install pytest .
+        run: pip install ".[test]"
 
       - name: Run tests
         run: pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ LABEL org.opencontainers.image.source="https://github.com/krahlos/matrix-webhook
 LABEL org.opencontainers.image.description="Webhook-to-Matrix notification bridge with per-sender bot users"
 LABEL maintainer="${MAINTAINER}"
 
-# wget is needed for the HEALTHCHECK probe
 RUN apt-get update \
  && apt-get install -y --no-install-recommends wget \
  && rm -rf /var/lib/apt/lists/*
@@ -46,6 +45,6 @@ USER bridge
 EXPOSE 5001
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget --spider -q http://localhost:5001/healthy || exit 1
+    CMD ["matrix-webhook-bridge", "healthcheck"]
 
 CMD ["matrix-webhook-bridge", "serve", "--config", "/etc/matrix-webhook-bridge/bridge.yml"]

--- a/matrix_webhook_bridge/cli.py
+++ b/matrix_webhook_bridge/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import os
 import sys
 from urllib.request import Request, urlopen
 
@@ -28,7 +29,7 @@ def _cmd_serve(args: argparse.Namespace) -> None:
 
 
 def _cmd_healthcheck(args: argparse.Namespace) -> None:
-    port = args.port or 5001
+    port = args.port or int(os.environ.get("PORT", 5001))
     try:
         urlopen(f"http://localhost:{port}/healthy")
     except Exception:

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -1,16 +1,21 @@
+import asyncio
 import hmac
 import json
 import logging
 import os
 import re
 import signal
+import threading
 import time
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import parse_qs, urlparse
+from contextlib import asynccontextmanager
+
+import uvicorn
+from fastapi import Depends, FastAPI, HTTPException, Request
 
 from .config import Config
 from .formatters import SERVICES, format_generic
-from .matrix import _SECRETS_DIR, _token, _token_path, notify
+from .matrix import _SECRETS_DIR, _token, _token_path
+from .matrix import notify as _matrix_notify
 
 logger = logging.getLogger(__name__)
 
@@ -69,124 +74,96 @@ def _format_uptime(seconds: int) -> str:
     return f"{d}d {h}h {m}m"
 
 
-def _make_handler(config: Config) -> type:
-    class Handler(BaseHTTPRequestHandler):
-        def do_GET(self):
-            if self.path == "/healthy":
-                logger.debug(f"Healthcheck from {self.client_address}")
-                uptime = _format_uptime(int(time.monotonic() - _start_time))
-                body = json.dumps({"status": "ok", "uptime": uptime}).encode()
-                self.send_response(200)
-                self.send_header("Content-Type", "application/json")
-                self.send_header("Content-Length", str(len(body)))
-                self.end_headers()
-                self.wfile.write(body)
-            else:
-                logger.warning(f"GET {self.path} not found from {self.client_address}")
-                self.send_response(404)
-                self.end_headers()
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    _pre_flight_check(app.state.config)
+    if threading.current_thread() is threading.main_thread():
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(
+            signal.SIGHUP,
+            lambda: (_token.cache_clear(), logger.info("Token cache cleared via SIGHUP")),
+        )
+    yield
 
-        def _check_auth(self) -> bool:
-            if not config.webhook_secret:
-                return True
-            auth = self.headers.get("Authorization", "")
-            expected = f"Bearer {config.webhook_secret}"
-            if not hmac.compare_digest(auth, expected):
-                logger.warning(
-                    "Unauthorized request from %s",
-                    self.client_address,
-                )
-                self.send_response(401)
-                self.end_headers()
-                return False
-            return True
 
-        def do_POST(self):
-            parsed = urlparse(self.path)
-            if parsed.path != "/notify":
-                logger.warning(f"POST {self.path} not found from {self.client_address}")
-                self.send_response(404)
-                self.end_headers()
-                return
+app = FastAPI(lifespan=_lifespan)
 
-            if not self._check_auth():
-                return
 
-            params = parse_qs(parsed.query)
-            service = params.get("service", [None])[0]
-            user = config.service_users.get(service) if service else None
-            user = user or config.default_user
+def _get_config(request: Request) -> Config:
+    return request.app.state.config
 
-            format_fn = SERVICES.get(service, format_generic)
-            user_id = f"@{user}:{config.domain}"
 
-            logger.info(
-                "POST /notify",
-                extra={
-                    "service": service,
-                    "user": user,
-                    "client": str(self.client_address),
-                },
+def _check_auth(
+    request: Request,
+    config: Config = Depends(_get_config),
+) -> None:
+    if not config.webhook_secret:
+        return
+    auth = request.headers.get("Authorization", "")
+    if not hmac.compare_digest(auth, f"Bearer {config.webhook_secret}"):
+        raise HTTPException(status_code=401)
+
+
+@app.get("/healthy")
+def healthy(config: Config = Depends(_get_config)):
+    uptime = _format_uptime(int(time.monotonic() - _start_time))
+    return {"status": "ok", "uptime": uptime}
+
+
+@app.post("/notify")
+async def notify(
+    request: Request,
+    service: str | None = None,
+    config: Config = Depends(_get_config),
+    _: None = Depends(_check_auth),
+):
+    body = await request.body()
+    if len(body) > 1_048_576:
+        raise HTTPException(status_code=413)
+    try:
+        data = json.loads(body)
+    except Exception:
+        raise HTTPException(status_code=400)
+
+    user = config.service_users.get(service) if service else None
+    user = user or config.default_user
+    format_fn = SERVICES.get(service, format_generic)
+    user_id = f"@{user}:{config.domain}"
+
+    logger.info(
+        "POST /notify",
+        extra={
+            "service": service,
+            "user": user,
+            "client": request.client.host if request.client else "unknown",
+        },
+    )
+
+    failed = False
+    for plain, html in format_fn(data):
+        try:
+            await asyncio.to_thread(
+                _matrix_notify,
+                config.base_url,
+                config.room_id,
+                plain,
+                html,
+                _token_path(user),
+                user_id,
+                config.matrix_timeout,
             )
-            try:
-                content_length = int(self.headers["Content-Length"])
-                if content_length > 1_048_576:
-                    self.send_response(413)
-                    self.end_headers()
-                    return
-                raw_data = self.rfile.read(content_length)
-                data = json.loads(raw_data)
-                logger.debug(f"Received data: {data}")
-            except Exception as e:
-                logger.error(f"Failed to parse JSON: {e}")
-                self.send_response(400)
-                self.end_headers()
-                return
+        except Exception as e:
+            logger.error(
+                "notify failed",
+                extra={"service": service, "user": user, "error": str(e)},
+            )
+            failed = True
 
-            failed = False
-            for plain, html in format_fn(data):
-                try:
-                    notify(
-                        config.base_url,
-                        config.room_id,
-                        plain,
-                        html,
-                        _token_path(user),
-                        user_id,
-                        config.matrix_timeout,
-                    )
-                except Exception as e:
-                    logger.error(
-                        "notify failed",
-                        extra={"service": service, "user": user, "error": str(e)},
-                    )
-                    failed = True
-            self.send_response(500 if failed else 200)
-            self.end_headers()
-
-        def log_message(self, *_) -> None:
-            pass
-
-    return Handler
+    if failed:
+        raise HTTPException(status_code=500)
 
 
 def run_server(config: Config) -> None:
-    _pre_flight_check(config)
-    signal.signal(
-        signal.SIGHUP,
-        lambda *_: (
-            _token.cache_clear(),
-            logger.info("Token cache cleared via SIGHUP"),
-        ),
-    )
-    server = ThreadingHTTPServer(("", config.port), _make_handler(config))
+    app.state.config = config
     logger.info(f"Starting Matrix notifier server on port {config.port}...")
-    try:
-        server.serve_forever()
-    except KeyboardInterrupt:
-        logger.info("Received shutdown signal (KeyboardInterrupt). Shutting down gracefully...")
-    except Exception as e:
-        logger.error(f"Server error: {e}")
-    finally:
-        server.server_close()
-        logger.info("Matrix notifier server stopped.")
+    uvicorn.run(app, host="", port=config.port, access_log=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
 [project.scripts]
 matrix-webhook-bridge = "matrix_webhook_bridge.cli:main"
 
-[dependency-groups]
-dev = ["pytest>=8", "httpx>=0.27"]
+[project.optional-dependencies]
+test = ["pytest>=8", "httpx>=0.27"]
 
 [tool.ruff]
 target-version = "py313"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,17 @@ requires-python = ">=3.11"
 readme = "README.md"
 license = { text = "MIT" }
 dependencies = [
+    "fastapi>=0.115,<1.0",
     "jsonschema>=4.0,<5.0",
     "pyyaml>=6.0,<7.0",
+    "uvicorn[standard]>=0.30,<1.0",
 ]
 
 [project.scripts]
 matrix-webhook-bridge = "matrix_webhook_bridge.cli:main"
+
+[dependency-groups]
+dev = ["pytest>=8", "httpx>=0.27"]
 
 [tool.ruff]
 target-version = "py313"

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -1,13 +1,13 @@
 """Tests for /notify request body size limit."""
 
-from http.server import HTTPServer
-from threading import Thread
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
+from starlette.testclient import TestClient
 
 from matrix_webhook_bridge.config import Config
-from matrix_webhook_bridge.server import _make_handler
+from matrix_webhook_bridge.server import _get_config, app
 
 
 @pytest.fixture
@@ -27,27 +27,13 @@ def _make_config(**overrides) -> Config:
     return Config(**defaults)
 
 
-def _start_server(config):
-    handler = _make_handler(config)
-    server = HTTPServer(("127.0.0.1", 0), handler)
-    port = server.server_address[1]
-    Thread(target=server.serve_forever, daemon=True).start()
-    return server, port
-
-
-def _post_raw(port, data: bytes):
-    import http.client
-
-    conn = http.client.HTTPConnection("127.0.0.1", port)
-    conn.request(
-        "POST",
-        "/notify",
-        body=data,
-        headers={"Content-Type": "application/json", "Content-Length": str(len(data))},
-    )
-    resp = conn.getresponse()
-    conn.close()
-    return resp.status
+@contextmanager
+def _make_client(config):
+    app.dependency_overrides[_get_config] = lambda: config
+    app.state.config = config
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    app.dependency_overrides.clear()
 
 
 @pytest.mark.usefixtures("_mock_secrets")
@@ -55,21 +41,16 @@ class TestBodySizeLimit:
     def test_body_at_limit_is_accepted(self):
         """A 1 MB body must not be rejected with 413."""
         config = _make_config()
-        server, port = _start_server(config)
-        with patch("matrix_webhook_bridge.server.notify"):
-            payload = b'{"body": "' + b"x" * (1_048_576 - 12) + b'"}'
-            try:
-                assert _post_raw(port, payload) != 413
-            finally:
-                server.shutdown()
+        payload = b'{"body": "' + b"x" * (1_048_576 - 12) + b'"}'
+        with _make_client(config) as client:
+            with patch("matrix_webhook_bridge.server._matrix_notify"):
+                resp = client.post("/notify", content=payload)
+                assert resp.status_code != 413
 
     def test_body_over_limit_returns_413(self):
         """A body exceeding 1 MB must be rejected with 413."""
         config = _make_config()
-        server, port = _start_server(config)
-        with patch("matrix_webhook_bridge.server.notify"):
-            payload = b"x" * 1_048_577
-            try:
-                assert _post_raw(port, payload) == 413
-            finally:
-                server.shutdown()
+        payload = b"x" * 1_048_577
+        with _make_client(config) as client:
+            resp = client.post("/notify", content=payload)
+            assert resp.status_code == 413

--- a/tests/test_webhook_auth.py
+++ b/tests/test_webhook_auth.py
@@ -1,14 +1,13 @@
 """Tests for webhook authentication."""
 
-import json
-from http.server import HTTPServer
-from threading import Thread
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
+from starlette.testclient import TestClient
 
 from matrix_webhook_bridge.config import Config
-from matrix_webhook_bridge.server import _make_handler
+from matrix_webhook_bridge.server import _get_config, app
 
 
 @pytest.fixture
@@ -31,34 +30,17 @@ def _make_config(**overrides) -> Config:
 
 @pytest.fixture
 def _mock_notify():
-    with patch("matrix_webhook_bridge.server.notify") as m:
+    with patch("matrix_webhook_bridge.server._matrix_notify") as m:
         yield m
 
 
-def _start_server(config):
-    handler = _make_handler(config)
-    server = HTTPServer(("127.0.0.1", 0), handler)
-    port = server.server_address[1]
-    thread = Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    return server, port
-
-
-def _post(port, path="/notify", headers=None, body=None):
-    from urllib.request import Request, urlopen
-
-    url = f"http://127.0.0.1:{port}{path}"
-    data = json.dumps(body or {"body": "test"}).encode()
-    req = Request(url, data=data, method="POST")
-    req.add_header("Content-Type", "application/json")
-    if headers:
-        for k, v in headers.items():
-            req.add_header(k, v)
-    try:
-        with urlopen(req) as r:
-            return r.status
-    except Exception as e:
-        return e.code
+@contextmanager
+def _make_client(config):
+    app.dependency_overrides[_get_config] = lambda: config
+    app.state.config = config
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    app.dependency_overrides.clear()
 
 
 @pytest.mark.usefixtures("_mock_secrets", "_mock_notify")
@@ -66,52 +48,42 @@ class TestWebhookAuth:
     def test_no_secret_allows_all(self):
         """Without webhook_secret, requests need no auth."""
         config = _make_config()
-        server, port = _start_server(config)
-        try:
-            assert _post(port) == 200
-        finally:
-            server.shutdown()
+        with _make_client(config) as client:
+            resp = client.post("/notify", json={"body": "test"})
+            assert resp.status_code == 200
 
     def test_secret_rejects_missing_header(self):
         """With webhook_secret, missing Authorization returns 401."""
         config = _make_config(webhook_secret="s3cret")
-        server, port = _start_server(config)
-        try:
-            assert _post(port) == 401
-        finally:
-            server.shutdown()
+        with _make_client(config) as client:
+            resp = client.post("/notify", json={"body": "test"})
+            assert resp.status_code == 401
 
     def test_secret_rejects_wrong_token(self):
         """With webhook_secret, wrong token returns 401."""
         config = _make_config(webhook_secret="s3cret")
-        server, port = _start_server(config)
-        try:
-            status = _post(port, headers={"Authorization": "Bearer wrong"})
-            assert status == 401
-        finally:
-            server.shutdown()
+        with _make_client(config) as client:
+            resp = client.post(
+                "/notify",
+                json={"body": "test"},
+                headers={"Authorization": "Bearer wrong"},
+            )
+            assert resp.status_code == 401
 
     def test_secret_accepts_correct_token(self):
         """With webhook_secret, correct Bearer token returns 200."""
         config = _make_config(webhook_secret="s3cret")
-        server, port = _start_server(config)
-        try:
-            status = _post(
-                port,
+        with _make_client(config) as client:
+            resp = client.post(
+                "/notify",
+                json={"body": "test"},
                 headers={"Authorization": "Bearer s3cret"},
             )
-            assert status == 200
-        finally:
-            server.shutdown()
+            assert resp.status_code == 200
 
     def test_healthcheck_unauthenticated(self):
         """GET /healthy never requires auth."""
-        from urllib.request import urlopen
-
         config = _make_config(webhook_secret="s3cret")
-        server, port = _start_server(config)
-        try:
-            with urlopen(f"http://127.0.0.1:{port}/healthy") as r:
-                assert r.status == 200
-        finally:
-            server.shutdown()
+        with _make_client(config) as client:
+            resp = client.get("/healthy")
+            assert resp.status_code == 200


### PR DESCRIPTION
- Replace `ThreadingHTTPServer`/`BaseHTTPRequestHandler` with a module-level FastAPI app and uvicorn
- Config injected via `app.state`; `_get_config` and `_check_auth` as named `Depends` providers
- Async `notify` handler; blocking Matrix call offloaded with `asyncio.to_thread`
- Tests migrated to `starlette.testclient.TestClient`; no real sockets or ports
- `healthcheck` CLI command replaces `wget` as the Docker HEALTHCHECK probe; `wget` kept for diagnostics
- `healthcheck` now honours `$PORT` env var

Closes #52