### PR TITLE
feat: add request IDs to structured logs

### DIFF
--- a/matrix_webhook_bridge/log.py
+++ b/matrix_webhook_bridge/log.py
@@ -2,6 +2,9 @@ import json
 import logging
 import os
 import time
+from contextvars import ContextVar
+
+request_id: ContextVar[str] = ContextVar("request_id", default="")
 
 _STDLIB_ATTRS = frozenset(
     {
@@ -44,11 +47,21 @@ class _JsonFormatter(logging.Formatter):
         if record.exc_info:
             entry["exc"] = self.formatException(record.exc_info)
         extra = {
-            k: v for k, v in record.__dict__.items() if k not in _STDLIB_ATTRS and not k.startswith("_")
+            k: v
+            for k, v in record.__dict__.items()
+            if k not in _STDLIB_ATTRS and not k.startswith("_")
         }
         if extra:
             entry.update(extra)
         return json.dumps(entry, default=str)
+
+
+class _RequestIdFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        rid = request_id.get()
+        if rid:
+            record.request_id = rid
+        return True
 
 
 def setup_logging() -> None:
@@ -56,4 +69,5 @@ def setup_logging() -> None:
     log_level = logging.DEBUG if debug else logging.INFO
     handler = logging.StreamHandler()
     handler.setFormatter(_JsonFormatter())
+    handler.addFilter(_RequestIdFilter())
     logging.basicConfig(level=log_level, handlers=[handler])

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -8,12 +8,14 @@ import signal
 import threading
 import time
 from contextlib import asynccontextmanager
+from uuid import uuid4
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Request
 
 from .config import Config
 from .formatters import SERVICES, format_generic
+from .log import request_id as _request_id
 from .matrix import _SECRETS_DIR, _token, _token_path
 from .matrix import notify as _matrix_notify
 
@@ -117,6 +119,8 @@ async def notify(
     config: Config = Depends(_get_config),
     _: None = Depends(_check_auth),
 ):
+    _request_id.set(uuid4().hex[:8])
+
     body = await request.body()
     if len(body) > 1_048_576:
         raise HTTPException(status_code=413)


### PR DESCRIPTION
Generate an 8-char hex request ID per `/notify` call and inject it into all related log lines via a `ContextVar` + logging filter. Since `asyncio.to_thread` copies the current context, downstream Matrix send logs in `matrix.py` pick it up automatically without any signature changes.

Closes #15