### PR TITLE
feat(matrix): retry sends on transient 5xx and network errors

### DIFF
--- a/matrix_webhook_bridge/matrix.py
+++ b/matrix_webhook_bridge/matrix.py
@@ -1,15 +1,16 @@
 import json
 import logging
+import time
 from functools import lru_cache
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from urllib.parse import quote
 from urllib.request import Request, urlopen
 from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
-
 _SECRETS_DIR = "/run/secrets"
+_RETRY_DELAYS = (1, 2, 4)  # seconds before attempts 2, 3, 4
 
 
 def _token_path(user: str) -> str:
@@ -22,7 +23,13 @@ def _token(path: str) -> str:
 
 
 def notify(
-    base_url: str, room_id: str, plain: str, html: str, token_file: str, user_id: str, timeout: int = 5
+    base_url: str,
+    room_id: str,
+    plain: str,
+    html: str,
+    token_file: str,
+    user_id: str,
+    timeout: int = 5,
 ) -> None:
     """Send a message to the Matrix room."""
     txn = uuid4().hex
@@ -30,7 +37,7 @@ def notify(
         f"{base_url}/_matrix/client/v3/rooms/{quote(room_id, safe='')}"
         f"/send/m.room.message/{txn}?user_id={quote(user_id, safe='')}"
     )
-    body = json.dumps(
+    payload = json.dumps(
         {
             "msgtype": "m.text",
             "body": plain,
@@ -38,32 +45,48 @@ def notify(
             "formatted_body": html,
         }
     ).encode()
-    req = Request(
-        url,
-        data=body,
-        method="PUT",
-        headers={
-            "Authorization": f"Bearer {_token(token_file)}",
-            "Content-Type": "application/json",
-        },
-    )
-    logger.debug(f"Sending Matrix message as {user_id}: {plain}")
-    try:
-        with urlopen(req, timeout=timeout) as r:
-            r.read()
-    except HTTPError as e:
-        # The JSON body carries the real reason (errcode, error, retry_after_ms).
-        # str(e) is only the status line, so include the body in the log and in
-        # the re-raised exception so callers see it too.
-        try:
-            body = e.read().decode("utf-8", errors="replace")
-        except Exception:  # noqa: BLE001 - best-effort; never let logging crash the send path
-            body = ""
-        logger.error(
-            "Matrix send failed (%s %s): %s",
-            e.code,
-            e.reason,
-            body,
+
+    delays = iter(_RETRY_DELAYS)
+    while True:
+        req = Request(
+            url,
+            data=payload,
+            method="PUT",
+            headers={
+                "Authorization": f"Bearer {_token(token_file)}",
+                "Content-Type": "application/json",
+            },
         )
-        raise HTTPError(e.url, e.code, f"{e.reason}: {body}", e.headers, None) from e
-    logger.info(f"Matrix message sent as {user_id}")
+        logger.debug("Sending Matrix message as %s: %s", user_id, plain)
+        try:
+            with urlopen(req, timeout=timeout) as r:
+                r.read()
+            logger.info("Matrix message sent as %s", user_id)
+            return
+        except HTTPError as e:
+            try:
+                err_body = e.read().decode("utf-8", errors="replace")
+            except Exception:  # noqa: BLE001
+                err_body = ""
+            wrapped = HTTPError(e.url, e.code, f"{e.reason}: {err_body}", e.headers, None)
+            if e.code < 500:
+                logger.error("Matrix send failed (%s %s): %s", e.code, e.reason, err_body)
+                raise wrapped from e
+            delay = next(delays, None)
+            if delay is None:
+                logger.error("Matrix send failed (%s %s): %s", e.code, e.reason, err_body)
+                raise wrapped from e
+            logger.warning(
+                "Matrix send failed (%s %s), retrying in %ds: %s",
+                e.code,
+                e.reason,
+                delay,
+                err_body,
+            )
+        except URLError as e:
+            delay = next(delays, None)
+            if delay is None:
+                logger.error("Matrix send failed: %s", e)
+                raise
+            logger.warning("Matrix send failed (%s), retrying in %ds", e, delay)
+        time.sleep(delay)


### PR DESCRIPTION
Wrap the `urlopen` call in a retry loop with 1 s / 2 s / 4 s backoff (4 attempts total). 5xx responses and `URLError` (timeouts, connection refused) are retried; 4xx errors fail immediately. The same transaction ID is reused across retries so Matrix deduplicates on the server side if a send succeeded but the response was lost.

Closes #11