### PR TITLE
feat(server): add GET /healthy/matrix endpoint

### DIFF
--- a/matrix_webhook_bridge/matrix.py
+++ b/matrix_webhook_bridge/matrix.py
@@ -7,6 +7,8 @@ from urllib.parse import quote
 from urllib.request import Request, urlopen
 from uuid import uuid4
 
+VERSIONS_PATH = "/_matrix/client/versions"
+
 logger = logging.getLogger(__name__)
 
 _SECRETS_DIR = "/run/secrets"
@@ -20,6 +22,14 @@ def _token_path(user: str) -> str:
 @lru_cache
 def _token(path: str) -> str:
     return open(path).read().strip()
+
+
+def probe(base_url: str, timeout: int = 5) -> None:
+    """GET /_matrix/client/versions to check homeserver reachability."""
+    url = f"{base_url}{VERSIONS_PATH}"
+    req = Request(url, method="GET")
+    with urlopen(req, timeout=timeout) as r:
+        r.read()
 
 
 def notify(

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -18,6 +18,7 @@ from .formatters import SERVICES, format_generic
 from .log import request_id as _request_id
 from .matrix import _SECRETS_DIR, _token, _token_path
 from .matrix import notify as _matrix_notify
+from .matrix import probe as _matrix_probe
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,18 @@ def _check_auth(
 def healthy(config: Config = Depends(_get_config)):
     uptime = _format_uptime(int(time.monotonic() - _start_time))
     return {"status": "ok", "uptime": uptime}
+
+
+@app.get("/healthy/matrix")
+async def healthy_matrix(config: Config = Depends(_get_config)):
+    try:
+        await asyncio.to_thread(_matrix_probe, config.base_url, config.matrix_timeout)
+    except Exception as e:
+        raise HTTPException(
+            status_code=503,
+            detail={"status": "error", "base_url": config.base_url, "detail": str(e)},
+        )
+    return {"status": "ok", "base_url": config.base_url}
 
 
 @app.post("/notify")

--- a/tests/test_healthy_matrix.py
+++ b/tests/test_healthy_matrix.py
@@ -1,0 +1,62 @@
+"""Tests for GET /healthy/matrix endpoint."""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+from urllib.error import URLError
+
+import pytest
+from starlette.testclient import TestClient
+
+from matrix_webhook_bridge.config import Config
+from matrix_webhook_bridge.server import _get_config, app
+
+
+@pytest.fixture
+def _mock_secrets(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+    (tmp_path / "bridge_as_token.txt").write_text("fake-as-token")
+
+
+def _make_config(**overrides) -> Config:
+    defaults = {
+        "base_url": "https://matrix.example.com",
+        "room_id": "!room:example.com",
+        "domain": "example.com",
+    }
+    defaults.update(overrides)
+    return Config(**defaults)
+
+
+@contextmanager
+def _make_client(config):
+    app.dependency_overrides[_get_config] = lambda: config
+    app.state.config = config
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestHealthyMatrix:
+    def test_reachable_returns_200(self):
+        config = _make_config()
+        with _make_client(config) as client:
+            with patch("matrix_webhook_bridge.server._matrix_probe"):
+                resp = client.get("/healthy/matrix")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok", "base_url": "https://matrix.example.com"}
+
+    def test_unreachable_returns_503(self):
+        config = _make_config()
+        with _make_client(config) as client:
+            with patch(
+                "matrix_webhook_bridge.server._matrix_probe",
+                side_effect=URLError("Name or service not known"),
+            ):
+                resp = client.get("/healthy/matrix")
+        assert resp.status_code == 503
+        body = resp.json()
+        assert body["detail"]["status"] == "error"
+        assert body["detail"]["base_url"] == "https://matrix.example.com"
+        assert "Name or service not known" in body["detail"]["detail"]


### PR DESCRIPTION
- Add `GET /healthy/matrix` endpoint that probes `/_matrix/client/versions` on the configured homeserver
- Returns `{"status": "ok", "base_url": "..."}` (HTTP 200) when reachable, `{"status": "error", ...}` (HTTP 503) when not

Closes #59