### PR TITLE
fix(ci): install test extras in release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -96,7 +96,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: pip install pytest .
+        run: pip install ".[test]"
 
       - name: Run tests
         run: pytest


### PR DESCRIPTION
- Release workflow used `pip install pytest .` instead of `pip install ".[test]"`, missing the test extras and causing `httpx` not to be installed