### PR TITLE
feat(server): add per-service multi room routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,32 @@ curl -X POST "http://localhost:5001/notify?service=alertmanager" \
 | Parameter | Description                                                                            |
 | --------- | -------------------------------------------------------------------------------------- |
 | `service` | Activates a built-in formatter and selects the sender via `service_users` in config    |
+| `room`    | Sends to this Matrix room ID, overriding any server-side routing                       |
 
 The sender (Matrix user localpart and token) is determined server-side: the `service_users` map
 in `bridge.yml` maps each service name to its user localpart. If the service is not listed,
 `default_user` is used.
+
+## Multi-room routing
+
+By default all messages go to the global `room_id` in `bridge.yml`. You can route per service
+by adding a `service_rooms` map under `server:`:
+
+```yaml
+server:
+  service_rooms:
+    alertmanager:
+      - "!abc123:matrix.example.org"
+      - "!def456:matrix.example.org"
+    borgmatic:
+      - "!abc123:matrix.example.org"
+```
+
+Room resolution order (first match wins):
+
+1. `?room=<id>` — message is sent to exactly this one room, ignoring any config
+2. `service_rooms[service]` — message is sent to all rooms listed for the service
+3. `matrix.room_id` — fallback, single room
 
 ## Built-in formatters
 

--- a/bridge.yml.example
+++ b/bridge.yml.example
@@ -32,3 +32,13 @@ server:
   #   alertmanager: alertmanager
   #   borgmatic: borgmatic
   #   crowdsec: crowdsec
+
+  # Map each ?service= value to one or more Matrix room IDs.
+  # If a service is not listed here, matrix.room_id is used.
+  # Callers can also pass ?room=!id:domain to target a specific room per request.
+  # service_rooms:
+  #   alertmanager:
+  #     - "!abc123:matrix.example.org"
+  #     - "!def456:matrix.example.org"
+  #   borgmatic:
+  #     - "!abc123:matrix.example.org"

--- a/matrix_webhook_bridge/config.py
+++ b/matrix_webhook_bridge/config.py
@@ -11,3 +11,4 @@ class Config:
     matrix_timeout: int = 5
     webhook_secret: str | None = None
     service_users: dict[str, str] = field(default_factory=dict)
+    service_rooms: dict[str, list[str]] = field(default_factory=dict)

--- a/matrix_webhook_bridge/config_loader.py
+++ b/matrix_webhook_bridge/config_loader.py
@@ -66,6 +66,17 @@ CONFIG_SCHEMA = {
                     "additionalProperties": {"type": "string", "minLength": 1},
                     "description": "Map of service name to Matrix user localpart",
                 },
+                "service_rooms": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[a-z0-9._\\-]+$": {
+                            "type": "array",
+                            "items": {"type": "string", "pattern": "^![^:]+:.+$"},
+                        }
+                    },
+                    "additionalProperties": False,
+                    "description": "Map of service name to list of Matrix room IDs",
+                },
             },
             "additionalProperties": False,
         },
@@ -127,4 +138,5 @@ def load_config_from_yaml(path: str) -> Config:
         default_user=server_section.get("default_user", "bridge"),
         webhook_secret=server_section.get("webhook_secret"),
         service_users=server_section.get("service_users", {}),
+        service_rooms=server_section.get("service_rooms", {}),
     )

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 _start_time = time.monotonic()
 _AS_TOKEN_RE = re.compile(r"^(.+)_as_token\.txt$")
 _VALID_LOCALPART_RE = re.compile(r"^[a-z0-9._\-]+$")
+_VALID_ROOM_ID_RE = re.compile(r"^![^:]+:.+$")
 
 
 def _pre_flight_check(config: Config) -> None:
@@ -42,6 +43,14 @@ def _pre_flight_check(config: Config) -> None:
                 f"Invalid user '{user}' for service '{svc}' in service_users. "
                 f"Must match [a-z0-9._-]+ to prevent path traversal."
             )
+
+    for svc, rooms in config.service_rooms.items():
+        for room_id in rooms:
+            if not _VALID_ROOM_ID_RE.match(room_id):
+                raise RuntimeError(
+                    f"Invalid room_id '{room_id}' for service '{svc}' in service_rooms. "
+                    f"Must match ^![^:]+:.+$ format."
+                )
 
     default_user_token_path = _token_path(config.default_user)
     if not os.path.isfile(default_user_token_path):
@@ -68,6 +77,18 @@ def _pre_flight_check(config: Config) -> None:
             )
 
     logger.info("Available appservice tokens: %s", ", ".join(available_tokens))
+
+
+def resolve_rooms(
+    service: str | None,
+    room_param: str | None,
+    config: Config,
+) -> list[str]:
+    if room_param:
+        return [room_param]
+    if service and config.service_rooms.get(service):
+        return config.service_rooms[service]
+    return [config.room_id]
 
 
 def _format_uptime(seconds: int) -> str:
@@ -129,6 +150,7 @@ async def healthy_matrix(config: Config = Depends(_get_config)):
 async def notify(
     request: Request,
     service: str | None = None,
+    room: str | None = None,
     config: Config = Depends(_get_config),
     _: None = Depends(_check_auth),
 ):
@@ -156,25 +178,27 @@ async def notify(
         },
     )
 
+    rooms = resolve_rooms(service, room, config)
     failed = False
     for plain, html in format_fn(data):
-        try:
-            await asyncio.to_thread(
-                _matrix_notify,
-                config.base_url,
-                config.room_id,
-                plain,
-                html,
-                _token_path(user),
-                user_id,
-                config.matrix_timeout,
-            )
-        except Exception as e:
-            logger.error(
-                "notify failed",
-                extra={"service": service, "user": user, "error": str(e)},
-            )
-            failed = True
+        for room_id in rooms:
+            try:
+                await asyncio.to_thread(
+                    _matrix_notify,
+                    config.base_url,
+                    room_id,
+                    plain,
+                    html,
+                    _token_path(user),
+                    user_id,
+                    config.matrix_timeout,
+                )
+            except Exception as e:
+                logger.error(
+                    "notify failed",
+                    extra={"service": service, "user": user, "room": room_id, "error": str(e)},
+                )
+                failed = True
 
     if failed:
         raise HTTPException(status_code=500)

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -354,6 +354,107 @@ matrix:
         Path(config_path).unlink()
 
 
+def test_load_config_with_service_rooms():
+    """service_rooms mapping is loaded when present."""
+    yaml_content = """
+matrix:
+  base_url: https://matrix.example.com
+  room_id: "!test:example.com"
+  domain: example.com
+
+server:
+  service_rooms:
+    alertmanager:
+      - "!abc123:matrix.example.org"
+      - "!def456:matrix.example.org"
+    borgmatic:
+      - "!abc123:matrix.example.org"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        config_path = f.name
+
+    try:
+        config = load_config_from_yaml(config_path)
+        assert config.service_rooms == {
+            "alertmanager": ["!abc123:matrix.example.org", "!def456:matrix.example.org"],
+            "borgmatic": ["!abc123:matrix.example.org"],
+        }
+    finally:
+        Path(config_path).unlink()
+
+
+def test_load_config_service_rooms_defaults_to_empty():
+    """service_rooms defaults to empty dict when omitted."""
+    yaml_content = """
+matrix:
+  base_url: https://matrix.example.com
+  room_id: "!test:example.com"
+  domain: example.com
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        config_path = f.name
+
+    try:
+        config = load_config_from_yaml(config_path)
+        assert config.service_rooms == {}
+    finally:
+        Path(config_path).unlink()
+
+
+def test_load_config_service_rooms_rejects_bad_room_id():
+    """ConfigError raised when a room ID in service_rooms has invalid format."""
+    yaml_content = """
+matrix:
+  base_url: https://matrix.example.com
+  room_id: "!test:example.com"
+  domain: example.com
+
+server:
+  service_rooms:
+    alertmanager:
+      - "not-a-room-id"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        config_path = f.name
+
+    try:
+        with pytest.raises(ConfigError):
+            load_config_from_yaml(config_path)
+    finally:
+        Path(config_path).unlink()
+
+
+def test_load_config_service_rooms_rejects_invalid_service_name():
+    """ConfigError raised when a service_rooms key has an invalid name."""
+    yaml_content = """
+matrix:
+  base_url: https://matrix.example.com
+  room_id: "!test:example.com"
+  domain: example.com
+
+server:
+  service_rooms:
+    "Invalid Service Name":
+      - "!abc123:matrix.example.org"
+"""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:
+        f.write(yaml_content)
+        f.flush()
+        config_path = f.name
+
+    try:
+        with pytest.raises(ConfigError):
+            load_config_from_yaml(config_path)
+    finally:
+        Path(config_path).unlink()
+
+
 def test_load_config_empty_file():
     """ConfigError raised when YAML file is empty."""
     with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as f:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,127 @@
+"""Tests for resolve_rooms helper and multi-room routing in /notify."""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from matrix_webhook_bridge.config import Config
+from matrix_webhook_bridge.server import _get_config, _pre_flight_check, app, resolve_rooms
+
+
+def _make_config(**kwargs) -> Config:
+    defaults = {
+        "base_url": "https://matrix.example.com",
+        "room_id": "!default:example.com",
+        "domain": "example.com",
+    }
+    defaults.update(kwargs)
+    return Config(**defaults)
+
+
+@contextmanager
+def _make_client(config):
+    app.dependency_overrides[_get_config] = lambda: config
+    app.state.config = config
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def _mock_secrets(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+    (tmp_path / "bridge_as_token.txt").write_text("fake-as-token")
+
+
+class TestResolveRooms:
+    def test_room_param_wins_over_service_rooms(self):
+        config = _make_config(service_rooms={"svc": ["!other:example.com"]})
+        assert resolve_rooms("svc", "!override:example.com", config) == ["!override:example.com"]
+
+    def test_room_param_wins_over_global_default(self):
+        config = _make_config()
+        assert resolve_rooms(None, "!override:example.com", config) == ["!override:example.com"]
+
+    def test_service_rooms_used_when_no_room_param(self):
+        config = _make_config(service_rooms={"svc": ["!a:example.com", "!b:example.com"]})
+        assert resolve_rooms("svc", None, config) == ["!a:example.com", "!b:example.com"]
+
+    def test_unknown_service_falls_back_to_global(self):
+        config = _make_config(service_rooms={"svc": ["!a:example.com"]})
+        assert resolve_rooms("other", None, config) == ["!default:example.com"]
+
+    def test_no_service_falls_back_to_global(self):
+        config = _make_config()
+        assert resolve_rooms(None, None, config) == ["!default:example.com"]
+
+    def test_no_service_rooms_configured_falls_back_to_global(self):
+        config = _make_config()
+        assert resolve_rooms("svc", None, config) == ["!default:example.com"]
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestNotifyMultiRoom:
+    def test_room_param_routes_to_specified_room(self):
+        config = _make_config()
+        with patch("matrix_webhook_bridge.server._matrix_notify") as mock_notify:
+            with _make_client(config) as client:
+                resp = client.post("/notify?room=!custom:example.com", json={"body": "hello"})
+        assert resp.status_code == 200
+        assert mock_notify.call_count == 1
+        assert mock_notify.call_args.args[1] == "!custom:example.com"
+
+    def test_service_rooms_sends_to_all_rooms(self):
+        config = _make_config(service_rooms={"svc": ["!room1:example.com", "!room2:example.com"]})
+        with patch("matrix_webhook_bridge.server._matrix_notify") as mock_notify:
+            with _make_client(config) as client:
+                resp = client.post("/notify?service=svc", json={"body": "hello"})
+        assert resp.status_code == 200
+        assert mock_notify.call_count == 2
+        called_rooms = [c.args[1] for c in mock_notify.call_args_list]
+        assert called_rooms == ["!room1:example.com", "!room2:example.com"]
+
+    def test_room_param_overrides_service_rooms(self):
+        config = _make_config(service_rooms={"svc": ["!room1:example.com"]})
+        with patch("matrix_webhook_bridge.server._matrix_notify") as mock_notify:
+            with _make_client(config) as client:
+                resp = client.post(
+                    "/notify?service=svc&room=!override:example.com", json={"body": "hello"}
+                )
+        assert resp.status_code == 200
+        assert mock_notify.call_count == 1
+        assert mock_notify.call_args.args[1] == "!override:example.com"
+
+    def test_no_service_rooms_uses_global_default(self):
+        config = _make_config()
+        with patch("matrix_webhook_bridge.server._matrix_notify") as mock_notify:
+            with _make_client(config) as client:
+                resp = client.post("/notify", json={"body": "hello"})
+        assert resp.status_code == 200
+        assert mock_notify.call_count == 1
+        assert mock_notify.call_args.args[1] == "!default:example.com"
+
+
+class TestPreFlightServiceRooms:
+    @pytest.fixture
+    def secrets_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
+        monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+        (tmp_path / "bridge_as_token.txt").write_text("tok")
+        return tmp_path
+
+    def test_accepts_valid_service_rooms(self, secrets_dir):
+        config = _make_config(service_rooms={"svc": ["!room1:example.com", "!room2:example.com"]})
+        _pre_flight_check(config)
+
+    def test_rejects_invalid_room_id_format(self, secrets_dir):
+        config = _make_config(service_rooms={"svc": ["not-a-room-id"]})
+        with pytest.raises(RuntimeError, match="Invalid room_id"):
+            _pre_flight_check(config)
+
+    def test_rejects_room_id_without_exclamation(self, secrets_dir):
+        config = _make_config(service_rooms={"svc": ["room:example.com"]})
+        with pytest.raises(RuntimeError, match="Invalid room_id"):
+            _pre_flight_check(config)


### PR DESCRIPTION
- Adds `service_rooms` config map to route each `?service=` to one or more Matrix rooms
- `?room=` query param overrides everything; unknown services fall back to the global `room_id` (backward compatible)

Closes #16