### PR TITLE
ci: exclude tests/docs from PR size and add changelog:skip label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,6 +1,9 @@
 ---
 
 changelog:
+  exclude:
+    labels:
+      - changelog:skip
   categories:
     - title: 🚨 Breaking Changes
       labels:

--- a/.github/workflows/pull_request_size.yml
+++ b/.github/workflows/pull_request_size.yml
@@ -27,3 +27,7 @@ jobs:
             This PR exceeds the recommended size of 1000 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.
+          files_to_ignore: |
+            **/test/**
+            **/tests/**
+            **/*.md


### PR DESCRIPTION
- Ignore test and markdown files from the PR size line-count check
- Add `changelog:skip` label to exclude CI/infra PRs from release notes