### PR TITLE
docs(server): add OpenAPI metadata, tags, and endpoint descriptions

### DIFF
--- a/dev_serve.py
+++ b/dev_serve.py
@@ -1,0 +1,28 @@
+"""Dev shim: redirects _SECRETS_DIR to ./secrets before startup.
+
+Usage:
+    uv run python dev_serve.py serve --config bridge.yml.example
+"""
+
+import sys
+from pathlib import Path
+
+# Patch before any bridge module uses the value
+import matrix_webhook_bridge.matrix as _m
+import matrix_webhook_bridge.server as _s
+
+_secrets = str(Path(__file__).parent / "secrets")
+_m._SECRETS_DIR = _secrets
+_s._SECRETS_DIR = _secrets
+
+# Create the secrets directory if it doesn't exist
+Path(_secrets).mkdir(exist_ok=True)
+
+# Create a fake token for the default user if it doesn't exist
+default_user_token_path = Path(_m._token_path("bridge"))
+if not default_user_token_path.is_file():
+    default_user_token_path.write_text("fake_token_for_dev")
+
+from matrix_webhook_bridge.cli import main  # noqa: E402
+
+sys.exit(main())

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -8,10 +8,11 @@ import signal
 import threading
 import time
 from contextlib import asynccontextmanager
+from importlib.metadata import version
 from uuid import uuid4
 
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 
 from .config import Config
 from .formatters import SERVICES, format_generic
@@ -26,6 +27,17 @@ _start_time = time.monotonic()
 _AS_TOKEN_RE = re.compile(r"^(.+)_as_token\.txt$")
 _VALID_LOCALPART_RE = re.compile(r"^[a-z0-9._\-]+$")
 _VALID_ROOM_ID_RE = re.compile(r"^![^:]+:.+$")
+
+_TAGS = [
+    {
+        "name": "health",
+        "description": "Liveness and readiness probes.",
+    },
+    {
+        "name": "notifications",
+        "description": "Forward webhook payloads to Matrix rooms.",
+    },
+]
 
 
 def _pre_flight_check(config: Config) -> None:
@@ -110,7 +122,16 @@ async def _lifespan(app: FastAPI):
     yield
 
 
-app = FastAPI(lifespan=_lifespan)
+app = FastAPI(
+    title="Matrix Webhook Bridge",
+    description=(
+        "Receives webhook POST requests and forwards formatted messages "
+        "to one or more Matrix rooms via the Matrix Application Service API."
+    ),
+    version=version("matrix-webhook-bridge"),
+    openapi_tags=_TAGS,
+    lifespan=_lifespan,
+)
 
 
 def _get_config(request: Request) -> Config:
@@ -128,14 +149,21 @@ def _check_auth(
         raise HTTPException(status_code=401)
 
 
-@app.get("/healthy")
+@app.get("/healthy", summary="Server health check", tags=["health"])
 def healthy(config: Config = Depends(_get_config)):
+    """Return server status and uptime."""
     uptime = _format_uptime(int(time.monotonic() - _start_time))
     return {"status": "ok", "uptime": uptime}
 
 
-@app.get("/healthy/matrix")
+@app.get(
+    "/healthy/matrix",
+    summary="Matrix homeserver health check",
+    tags=["health"],
+    responses={503: {"description": "Matrix homeserver is unreachable"}},
+)
 async def healthy_matrix(config: Config = Depends(_get_config)):
+    """Probe the configured Matrix homeserver and return its reachability status."""
     try:
         await asyncio.to_thread(_matrix_probe, config.base_url, config.matrix_timeout)
     except Exception as e:
@@ -146,14 +174,36 @@ async def healthy_matrix(config: Config = Depends(_get_config)):
     return {"status": "ok", "base_url": config.base_url}
 
 
-@app.post("/notify")
+@app.post(
+    "/notify",
+    summary="Send a webhook notification to Matrix",
+    tags=["notifications"],
+    responses={
+        400: {"description": "Request body is not valid JSON"},
+        401: {"description": "Missing or invalid Authorization header"},
+        413: {"description": "Request body exceeds 1 MiB"},
+        500: {"description": "One or more Matrix deliveries failed"},
+    },
+)
 async def notify(
     request: Request,
-    service: str | None = None,
-    room: str | None = None,
+    service: str | None = Query(
+        None,
+        description="Service name; selects the formatter, sending user, and target rooms",
+    ),
+    room: str | None = Query(
+        None,
+        description="Target room ID (e.g. !abc:example.com); overrides service_rooms",
+    ),
     config: Config = Depends(_get_config),
     _: None = Depends(_check_auth),
 ):
+    """Forward a webhook payload to one or more Matrix rooms.
+
+    The service parameter selects the formatter (defaults to generic), the
+    sending user (from service_users), and target rooms (from service_rooms).
+    The room parameter overrides target room selection regardless of service_rooms.
+    """
     _request_id.set(uuid4().hex[:8])
 
     body = await request.body()


### PR DESCRIPTION
- Add `title`, `description`, `version`, and `openapi_tags` to the `FastAPI()` constructor for a proper Swagger UI header
- Add `dev_serve.py` shim for local API docs browsing without `sudo`