### PR TITLE
feat(metrics): expose Prometheus counters at /metrics

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,6 +56,9 @@ docker compose up -d
 docker compose exec bridge matrix-webhook-bridge healthcheck
 ```
 
+`GET /healthy` — server liveness (uptime). `GET /healthy/matrix` — homeserver reachability.
+`GET /metrics` — Prometheus metrics (no auth required).
+
 ## Configuration reference
 
 All configuration is defined in the YAML configuration file (default: `config/bridge.yml`).

--- a/README.md
+++ b/README.md
@@ -80,3 +80,26 @@ Room resolution order (first match wins):
 | Service                  | `?service=` value | Description                                              |
 | ------------------------ | ----------------- | -------------------------------------------------------- |
 | Prometheus Alertmanager  | `alertmanager`    | Colour-coded alerts with severity, description and links |
+
+## Metrics
+
+Prometheus metrics are exposed at `GET /metrics` on the same port as the bridge. No authentication
+is required.
+
+| Metric                        | Labels    | Description                          |
+| ----------------------------- | --------- | ------------------------------------ |
+| `bridge_requests_total`       | `service` | Every `POST /notify` received        |
+| `bridge_notify_success_total` | `service` | Matrix send succeeded                |
+| `bridge_notify_failure_total` | `service` | Matrix send failed                   |
+| `bridge_invalid_payload_total`| `service` | 400 Bad Request (bad JSON/oversized) |
+| `bridge_auth_failure_total`   | —         | 401 Unauthorized                     |
+
+The `service` label is the `?service=` query value, or `""` for generic requests.
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: matrix-webhook-bridge
+    static_configs:
+      - targets: ["localhost:5001"]
+```

--- a/matrix_webhook_bridge/metrics.py
+++ b/matrix_webhook_bridge/metrics.py
@@ -1,0 +1,30 @@
+from prometheus_client import Counter
+
+requests_total = Counter(
+    "bridge_requests_total",
+    "Every POST /notify received",
+    ["service"],
+)
+
+notify_success_total = Counter(
+    "bridge_notify_success_total",
+    "Matrix send succeeded",
+    ["service"],
+)
+
+notify_failure_total = Counter(
+    "bridge_notify_failure_total",
+    "Matrix send failed",
+    ["service"],
+)
+
+invalid_payload_total = Counter(
+    "bridge_invalid_payload_total",
+    "400 Bad Request (malformed JSON or oversized)",
+    ["service"],
+)
+
+auth_failure_total = Counter(
+    "bridge_auth_failure_total",
+    "401 Unauthorized",
+)

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -13,7 +13,9 @@ from uuid import uuid4
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from prometheus_client import make_asgi_app
 
+from . import metrics
 from .config import Config
 from .formatters import SERVICES, format_generic
 from .log import request_id as _request_id
@@ -133,6 +135,8 @@ app = FastAPI(
     lifespan=_lifespan,
 )
 
+app.mount("/metrics", make_asgi_app())
+
 
 def _get_config(request: Request) -> Config:
     return request.app.state.config
@@ -146,6 +150,7 @@ def _check_auth(
         return
     auth = request.headers.get("Authorization", "")
     if not hmac.compare_digest(auth, f"Bearer {config.webhook_secret}"):
+        metrics.auth_failure_total.inc()
         raise HTTPException(status_code=401)
 
 
@@ -205,13 +210,16 @@ async def notify(
     The room parameter overrides target room selection regardless of service_rooms.
     """
     _request_id.set(uuid4().hex[:8])
+    metrics.requests_total.labels(service=service or "").inc()
 
     body = await request.body()
     if len(body) > 1_048_576:
+        metrics.invalid_payload_total.labels(service=service or "").inc()
         raise HTTPException(status_code=413)
     try:
         data = json.loads(body)
     except Exception:
+        metrics.invalid_payload_total.labels(service=service or "").inc()
         raise HTTPException(status_code=400)
 
     user = config.service_users.get(service) if service else None
@@ -243,11 +251,13 @@ async def notify(
                     user_id,
                     config.matrix_timeout,
                 )
+                metrics.notify_success_total.labels(service=service or "").inc()
             except Exception as e:
                 logger.error(
                     "notify failed",
                     extra={"service": service, "user": user, "room": room_id, "error": str(e)},
                 )
+                metrics.notify_failure_total.labels(service=service or "").inc()
                 failed = True
 
     if failed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = { text = "MIT" }
 dependencies = [
     "fastapi>=0.115,<1.0",
     "jsonschema>=4.0,<5.0",
+    "prometheus-client>=0.20,<1.0",
     "pyyaml>=6.0,<7.0",
     "uvicorn[standard]>=0.30,<1.0",
 ]


### PR DESCRIPTION
- Add `matrix_webhook_bridge/metrics.py` with five `bridge_*` counters
- Instrument `server.py`: requests, auth failures, invalid payloads, per-delivery success/failure
- Mount Prometheus ASGI app at `/metrics`

Closes #27