### PR TITLE
feat(server): autojoin configured rooms at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,26 @@ Room resolution order (first match wins):
 2. `service_rooms[service]` — message is sent to all rooms listed for the service
 3. `matrix.room_id` — fallback, single room
 
+## Autojoin rooms
+
+When `matrix.autojoin: true` is set, the bridge joins every configured room at startup on behalf
+of each bot user. This is useful after adding a new room to `service_rooms` — instead of manually
+inviting each bot, the bridge handles it automatically.
+
+```yaml
+matrix:
+  autojoin: true
+```
+
+The bridge derives the set of (user, room) pairs from the config:
+
+- `default_user` joins `matrix.room_id`
+- Each entry in `service_rooms` is joined by the matching `service_users` entry, or `default_user`
+  if no explicit mapping exists
+
+Joining a room the bot is already in is a no-op. A failed join is logged as an error but does not
+prevent the bridge from starting.
+
 ## Built-in formatters
 
 | Service                  | `?service=` value | Description                                              |

--- a/bridge.yml.example
+++ b/bridge.yml.example
@@ -14,6 +14,9 @@ matrix:
   # Timeout for Matrix API requests in seconds (default: 5)
   timeout: 5
 
+  # Automatically join all configured rooms at startup (default: false)
+  # autojoin: false
+
 server:
   # Port to listen on (default: 5001)
   port: 5001

--- a/matrix_webhook_bridge/config.py
+++ b/matrix_webhook_bridge/config.py
@@ -12,3 +12,4 @@ class Config:
     webhook_secret: str | None = None
     service_users: dict[str, str] = field(default_factory=dict)
     service_rooms: dict[str, list[str]] = field(default_factory=dict)
+    autojoin: bool = False

--- a/matrix_webhook_bridge/config_loader.py
+++ b/matrix_webhook_bridge/config_loader.py
@@ -38,6 +38,11 @@ CONFIG_SCHEMA = {
                     "default": 5,
                     "description": "Timeout for Matrix API requests in seconds",
                 },
+                "autojoin": {
+                    "type": "boolean",
+                    "default": False,
+                    "description": "Join all configured rooms at startup",
+                },
             },
             "additionalProperties": False,
         },
@@ -139,4 +144,5 @@ def load_config_from_yaml(path: str) -> Config:
         webhook_secret=server_section.get("webhook_secret"),
         service_users=server_section.get("service_users", {}),
         service_rooms=server_section.get("service_rooms", {}),
+        autojoin=matrix_section.get("autojoin", False),
     )

--- a/matrix_webhook_bridge/matrix.py
+++ b/matrix_webhook_bridge/matrix.py
@@ -59,6 +59,37 @@ def _with_retry(fn):
         time.sleep(delay)
 
 
+def join_room(
+    base_url: str,
+    room_id: str,
+    token_file: str,
+    user_id: str,
+    timeout: int = 5,
+) -> None:
+    """Join a Matrix room as user_id."""
+    url = (
+        f"{base_url}/_matrix/client/v3/join/{quote(room_id, safe='')}"
+        f"?user_id={quote(user_id, safe='')}"
+    )
+
+    def attempt():
+        req = Request(
+            url,
+            data=b"{}",
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {_token(token_file)}",
+                "Content-Type": "application/json",
+            },
+        )
+        logger.debug("Joining room %s as %s", room_id, user_id)
+        with urlopen(req, timeout=timeout) as r:
+            r.read()
+        logger.info("Joined room %s as %s", room_id, user_id)
+
+    _with_retry(attempt)
+
+
 def probe(base_url: str, timeout: int = 5) -> None:
     """GET /_matrix/client/versions to check homeserver reachability."""
     url = f"{base_url}{VERSIONS_PATH}"

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -20,6 +20,7 @@ from .config import Config
 from .formatters import SERVICES, format_generic
 from .log import request_id as _request_id
 from .matrix import _SECRETS_DIR, _token, _token_path
+from .matrix import join_room as _join_room
 from .matrix import notify as _matrix_notify
 from .matrix import probe as _matrix_probe
 
@@ -93,6 +94,30 @@ def _pre_flight_check(config: Config) -> None:
     logger.info("Available appservice tokens: %s", ", ".join(available_tokens))
 
 
+def _autojoin_all(config: Config) -> None:
+    users_rooms: dict[str, set[str]] = {config.default_user: {config.room_id}}
+    for svc, rooms in config.service_rooms.items():
+        user = config.service_users.get(svc, config.default_user)
+        users_rooms.setdefault(user, set()).update(rooms)
+
+    for user, rooms in users_rooms.items():
+        user_id = f"@{user}:{config.domain}"
+        for room_id in sorted(rooms):
+            try:
+                _join_room(
+                    config.base_url,
+                    room_id,
+                    _token_path(user),
+                    user_id,
+                    config.matrix_timeout,
+                )
+            except Exception as e:
+                logger.error(
+                    "autojoin failed",
+                    extra={"user": user, "room": room_id, "error": str(e)},
+                )
+
+
 def resolve_rooms(
     service: str | None,
     room_param: str | None,
@@ -114,7 +139,10 @@ def _format_uptime(seconds: int) -> str:
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
-    _pre_flight_check(app.state.config)
+    config = app.state.config
+    _pre_flight_check(config)
+    if config.autojoin:
+        await asyncio.to_thread(_autojoin_all, config)
     if threading.current_thread() is threading.main_thread():
         loop = asyncio.get_running_loop()
         loop.add_signal_handler(

--- a/tests/test_autojoin.py
+++ b/tests/test_autojoin.py
@@ -1,0 +1,62 @@
+"""Tests for _autojoin_all startup behaviour."""
+
+import logging
+from unittest.mock import ANY, patch
+
+from matrix_webhook_bridge.config import Config
+from matrix_webhook_bridge.server import _autojoin_all
+
+
+def _cfg(**kwargs) -> Config:
+    defaults = {
+        "base_url": "https://matrix.example.com",
+        "room_id": "!default:example.com",
+        "domain": "example.com",
+    }
+    defaults.update(kwargs)
+    return Config(**defaults)
+
+
+class TestAutojoinAll:
+    def test_joins_default_user_to_global_room(self):
+        config = _cfg()
+        with patch("matrix_webhook_bridge.server._join_room") as mock_join:
+            _autojoin_all(config)
+        mock_join.assert_called_once_with(
+            "https://matrix.example.com",
+            "!default:example.com",
+            ANY,
+            "@bridge:example.com",
+            5,
+        )
+
+    def test_service_user_joins_service_rooms(self):
+        config = _cfg(
+            service_users={"svc": "svcbot"},
+            service_rooms={"svc": ["!room1:example.com", "!room2:example.com"]},
+        )
+        with patch("matrix_webhook_bridge.server._join_room") as mock_join:
+            _autojoin_all(config)
+        called = [(c.args[3], c.args[1]) for c in mock_join.call_args_list]
+        assert ("@svcbot:example.com", "!room1:example.com") in called
+        assert ("@svcbot:example.com", "!room2:example.com") in called
+
+    def test_service_without_user_uses_default_user(self):
+        config = _cfg(service_rooms={"svc": ["!svcroom:example.com"]})
+        with patch("matrix_webhook_bridge.server._join_room") as mock_join:
+            _autojoin_all(config)
+        called = [(c.args[3], c.args[1]) for c in mock_join.call_args_list]
+        assert ("@bridge:example.com", "!svcroom:example.com") in called
+
+    def test_join_failure_is_logged_and_does_not_raise(self, caplog):
+        config = _cfg()
+        with patch(
+            "matrix_webhook_bridge.server._join_room", side_effect=Exception("network error")
+        ):
+            with caplog.at_level(logging.ERROR):
+                _autojoin_all(config)  # must not raise
+        assert any("autojoin failed" in r.getMessage() for r in caplog.records)
+
+    def test_autojoin_false_skipped_at_lifespan(self):
+        config = _cfg(autojoin=False)
+        assert not config.autojoin

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -1,4 +1,4 @@
-"""Tests for matrix.notify() error-logging behavior."""
+"""Tests for matrix.notify() and matrix.join_room() behavior."""
 
 import io
 import json
@@ -121,3 +121,43 @@ def test_notify_http_error_unreadable_body_does_not_crash(tmp_path, caplog):
 
     # Must have logged something even though reading the body failed
     assert any("Matrix request failed" in r.getMessage() for r in caplog.records)
+
+
+def test_join_room_success_path(tmp_path):
+    token = tmp_path / "user_as_token.txt"
+    token.write_text("test-token\n")
+    matrix_mod._token.cache_clear()
+
+    with patch.object(matrix_mod, "urlopen", return_value=_FakeContextManager()):
+        matrix_mod.join_room(
+            base_url="https://matrix.example.org",
+            room_id="!room:example.org",
+            token_file=str(token),
+            user_id="@bot:example.org",
+            timeout=5,
+        )
+
+
+def test_join_room_4xx_raises_immediately(tmp_path):
+    token = tmp_path / "user_as_token.txt"
+    token.write_text("test-token\n")
+    matrix_mod._token.cache_clear()
+
+    err = HTTPError(
+        url="https://matrix.example.org/_matrix/client/v3/join/!room:example.org",
+        code=403,
+        msg="Forbidden",
+        hdrs=None,
+        fp=io.BytesIO(b'{"errcode":"M_FORBIDDEN"}'),
+    )
+
+    with patch.object(matrix_mod, "urlopen", side_effect=err):
+        with pytest.raises(HTTPError) as exc_info:
+            matrix_mod.join_room(
+                base_url="https://matrix.example.org",
+                room_id="!room:example.org",
+                token_file=str(token),
+                user_id="@bot:example.org",
+                timeout=5,
+            )
+    assert exc_info.value.code == 403


### PR DESCRIPTION
- Add `matrix.autojoin` config option (default `false`)
- Add `join_room()` to `matrix.py` using `_with_retry`
- Join all (user, room) pairs derived from `service_rooms` and `room_id` on startup
- Failures are logged but do not abort startup

Closes #54