### PR TITLE
build(docker): use build-args for OCI labels in Dockerfile

### DIFF
--- a/.github/actions/publish_image/action.yml
+++ b/.github/actions/publish_image/action.yml
@@ -22,6 +22,9 @@ inputs:
   sha:
     description: "Full commit SHA for OCI revision label"
     required: true
+  build_date:
+    description: "ISO-8601 timestamp"
+    required: true
   server_url:
     description: "GitHub server URL for OCI source label"
     required: true
@@ -47,14 +50,14 @@ runs:
         platforms: linux/amd64
         push: true
         build-args: |
+          VERSION=${{ inputs.version }}
           MAINTAINER=${{ inputs.maintainer }}
+          IMAGE_REVISION=${{ inputs.sha }}
+          BUILD_DATE=${{ inputs.build_date }}
+          SOURCE_URL=${{ inputs.server_url }}/${{ inputs.image_name }}
         tags: |
           ${{ inputs.registry }}/${{ inputs.image_name }}:${{ inputs.version }}
           ${{ inputs.registry }}/${{ inputs.image_name }}:latest
-        labels: |
-          org.opencontainers.image.source=${{ inputs.server_url }}/${{ inputs.image_name }}
-          org.opencontainers.image.revision=${{ inputs.sha }}
-          org.opencontainers.image.version=${{ inputs.version }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,9 +45,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set Build Metadata
+        run: |
+          {
+            echo "IMAGE_VERSION=0.0.0-sha.${GITHUB_SHA::7}"
+            echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            echo "IMAGE_REVISION=${{ github.sha }}"
+          } >> "$GITHUB_ENV"
+
       - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: false
+          build-args: |
+            VERSION=${{ env.IMAGE_VERSION }}
+            MAINTAINER=${{ github.actor }}
+            IMAGE_REVISION=${{ env.IMAGE_REVISION }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            SOURCE_URL=${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -112,6 +112,11 @@ jobs:
         with:
           ref: ${{ inputs.version }}
 
+      - name: Set Build Metadata
+        id: meta
+        run: |
+          echo "date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_OUTPUT"
+
       - name: Publish image
         uses: ./.github/actions/publish_image
         with:
@@ -121,6 +126,7 @@ jobs:
           maintainer: ${{ vars.MAINTAINER }}
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.bump-version.outputs.sha }}
+          build_date: ${{ steps.meta.outputs.date }}
           server_url: ${{ github.server_url }}
 
   create-release:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -85,9 +85,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set Build Metadata
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            IMAGE_VERSION="0.0.0-pr.${{ github.event.number }}"
+          else
+            IMAGE_VERSION="0.0.0-sha.${GITHUB_SHA::7}"
+          fi
+
+          {
+            echo "IMAGE_VERSION=${IMAGE_VERSION}"
+            echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            echo "IMAGE_REVISION=${{ github.sha }}"
+          } >> "$GITHUB_ENV"
+
       - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: false
+          build-args: |
+            VERSION=${{ env.IMAGE_VERSION }}
+            MAINTAINER=${{ github.actor }}
+            IMAGE_REVISION=${{ env.IMAGE_REVISION }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
+            SOURCE_URL=${{ github.server_url }}/${{ github.repository }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,3 @@
+---
+ignored:
+  - DL3008  # Pin versions in apt get install

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,11 @@ repos:
       - id: shfmt
         args: [-i, "2", -ci, -s, -bn]
         files: \.sh$
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        args: [--write-changes]
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
   - repo: https://github.com/hadolint/hadolint
     rev: v2.12.0
     hooks:
-      - id: hadolint
+      - id: hadolint-docker
         args: [--config, .hadolint.yaml]
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,6 +43,15 @@ repos:
         args: [--fix]
         files: '\.md$'
         language_version: system
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+        args: [--config, .hadolint.yaml]
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,19 @@ RUN pip install --no-cache-dir .
 FROM python:3.12-slim
 
 ARG MAINTAINER="unknown"
+ARG VERSION="0.0.0-dev"
+ARG IMAGE_REVISION="unknown"
+ARG BUILD_DATE="unknown"
+ARG SOURCE_URL="https://github.com/krahlos/matrix-webhook-bridge"
 
-LABEL org.opencontainers.image.source="https://github.com/krahlos/matrix-webhook-bridge"
+LABEL org.opencontainers.image.title="Matrix Webhook Bridge"
 LABEL org.opencontainers.image.description="Webhook-to-Matrix notification bridge with per-sender bot users"
-LABEL maintainer="${MAINTAINER}"
+LABEL org.opencontainers.image.source="${SOURCE_URL}"
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.revision="${IMAGE_REVISION}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.authors="${MAINTAINER}"
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends wget \


### PR DESCRIPTION
- Move OCI label definitions from CI workflows to Dockerfile
- Use build arguments (`VERSION`, `MAINTAINER`, `IMAGE_REVISION`, `BUILD_DATE`, `SOURCE_URL`) to populate labels
- Standardize labels using OpenContainers (`org.opencontainers.image.*`) annotations