### PR TITLE
refactor(tokens): move token mount point from /run/secrets to /tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage.xml
 
 # Secrets & local config
 secrets/
+tokens/
 .env
 .env.*
 !.env.example

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,9 @@ repos:
     rev: v2.8.0
     hooks:
       - id: pip-audit
+        args: ["--ignore-vuln", "GHSA-58qw-9mgm-455v"]
+        # GHSA-58qw-9mgm-455v (CVE-2026-3219): vulnerability in pip itself (<=26.0.1),
+        # not a project dependency. Remove once pip 26.0.2+ is available.
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,6 +64,6 @@ On HTTP 5xx or network error the client retries up to 3 times with exponential b
 
 ## Token management
 
-Each Matrix user has an appservice token stored in `/run/secrets/<user>_as_token.txt`. Tokens
+Each Matrix user has an appservice token stored in `/tokens/<user>_as_token.txt`. Tokens
 are read once and cached in memory. `SIGHUP` invalidates the cache to force a re-read on the
 next request.

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,9 +45,7 @@ ENV PATH="/venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 ENV PORT=5001
 
-# Secrets are expected at /run/secrets/<user>_as_token.txt
-# Mount them via Docker secrets (Swarm) or a bind mount in compose.
-VOLUME ["/run/secrets"]
+VOLUME ["/tokens"]
 
 USER bridge
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ curl -fsSL https://raw.githubusercontent.com/krahlos/matrix-webhook-bridge/main/
 ### Manual Steps
 
 The installer downloads `docker-compose.yml`, creates `config/bridge.yml` from the example,
-generates `secrets/bridge_as_token.txt`, and bootstraps an `bridge-registration.yml` with the
+generates `tokens/bridge_as_token.txt`, and bootstraps an `bridge-registration.yml` with the
 token already filled in. What it cannot do is register the Application Service with your
 Synapse — that must be done manually.
 

--- a/MATRIX.md
+++ b/MATRIX.md
@@ -33,15 +33,15 @@ app_service_config_files:
 
 ## Create the AS token secret
 
-Generate a token and write it to the secrets file expected by `docker-compose.yml`:
+Generate a token and write it to the tokens file expected by `docker-compose.yml`:
 
 ```shell
-mkdir -p secrets
-openssl rand -hex 32 > secrets/bridge_as_token.txt
+mkdir -p tokens
+openssl rand -hex 32 > tokens/bridge_as_token.txt
 ```
 
 The `docker-compose.yml` already mounts this as a Docker secret at
-`/run/secrets/bridge_as_token.txt`. Use the same token value in the Application
+`/tokens/bridge_as_token.txt`. Use the same token value in the Application
 Service registration file under `as_token`.
 
 ## Get compatibility token for Synapse API
@@ -91,7 +91,7 @@ Call the join endpoint on behalf of the AS bot user using the AS token:
 
 ```shell
 curl -s -X POST \
-  -H "Authorization: Bearer $(cat secrets/bridge_as_token.txt)" \
+  -H "Authorization: Bearer $(cat tokens/bridge_as_token.txt)" \
   -H "Content-Type: application/json" \
   -d '{}' \
   "https://<matrix_base_url>/_matrix/client/v3/join/<room_id>?user_id=@bridge:<domain>"

--- a/dev_serve.py
+++ b/dev_serve.py
@@ -1,4 +1,4 @@
-"""Dev shim: redirects _SECRETS_DIR to ./secrets before startup.
+"""Dev shim: redirects _TOKENS_DIR to ./tokens before startup.
 
 Usage:
     uv run python dev_serve.py serve --config bridge.yml.example
@@ -10,12 +10,12 @@ from pathlib import Path
 import matrix_webhook_bridge.matrix as _m
 import matrix_webhook_bridge.server as _s
 
-_secrets = str(Path(__file__).parent / "secrets")
-_m._SECRETS_DIR = _secrets
-_s._SECRETS_DIR = _secrets
+_tokens = str(Path(__file__).parent / "tokens")
+_m._TOKENS_DIR = _tokens
+_s._TOKENS_DIR = _tokens
 
-# Create the secrets directory if it doesn't exist
-Path(_secrets).mkdir(exist_ok=True)
+# Create the tokens directory if it doesn't exist
+Path(_tokens).mkdir(exist_ok=True)
 
 # Create a fake token for the default user if it doesn't exist
 default_user_token_path = Path(_m._token_path("bridge"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
       - "5001:5001"
     volumes:
       - ./config/bridge.yml:/etc/matrix-webhook-bridge/bridge.yml:ro
-      - ./secrets:/run/secrets:ro
+      - ./tokens:/tokens:ro

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 BASE_URL="https://raw.githubusercontent.com/krahlos/matrix-webhook-bridge/main"
 
-for path in docker-compose.yml config secrets bridge-registration.yml; do
+for path in docker-compose.yml config tokens bridge-registration.yml; do
   if [ -e "$path" ]; then
     echo "Error: '$path' already exists. Run this installer in an empty directory." >&2
     exit 1
@@ -18,10 +18,10 @@ mkdir config
 curl -fsSL "$BASE_URL/bridge.yml.example" -o config/bridge.yml
 
 echo "Generating tokens and bootstrapping bridge-registration.yml..."
-mkdir secrets
+mkdir tokens
 AS_TOKEN=$(openssl rand -hex 32)
 HS_TOKEN=$(openssl rand -hex 32)
-echo "$AS_TOKEN" > secrets/bridge_as_token.txt
+echo "$AS_TOKEN" > tokens/bridge_as_token.txt
 curl -fsSL "$BASE_URL/bridge-registration.yml.example" -o bridge-registration.yml
 sed -i "s/<your_as_token_here>/$AS_TOKEN/g" bridge-registration.yml
 sed -i "s/<your_hs_token_here>/$HS_TOKEN/g" bridge-registration.yml

--- a/matrix_webhook_bridge/matrix.py
+++ b/matrix_webhook_bridge/matrix.py
@@ -11,12 +11,12 @@ VERSIONS_PATH = "/_matrix/client/versions"
 
 logger = logging.getLogger(__name__)
 
-_SECRETS_DIR = "/run/secrets"
+_TOKENS_DIR = "/tokens"
 _RETRY_DELAYS = (1, 2, 4)  # seconds before attempts 2, 3, 4
 
 
 def _token_path(user: str) -> str:
-    return f"{_SECRETS_DIR}/{user}_as_token.txt"
+    return f"{_TOKENS_DIR}/{user}_as_token.txt"
 
 
 @lru_cache

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -20,7 +20,7 @@ from . import metrics
 from .config import Config
 from .formatters import SERVICES, format_generic
 from .log import request_id as _request_id
-from .matrix import _SECRETS_DIR, _token, _token_path
+from .matrix import _TOKENS_DIR, _token, _token_path
 from .matrix import join_room as _join_room
 from .matrix import notify as _matrix_notify
 from .matrix import probe as _matrix_probe
@@ -78,7 +78,7 @@ def _pre_flight_check(config: Config) -> None:
 
     available_tokens: list[str] = []
     try:
-        entries = os.listdir(_SECRETS_DIR)
+        entries = os.listdir(_TOKENS_DIR)
     except FileNotFoundError:
         entries = []
 

--- a/tests/test_body_size_limit.py
+++ b/tests/test_body_size_limit.py
@@ -11,9 +11,9 @@ from matrix_webhook_bridge.server import _get_config, app
 
 
 @pytest.fixture
-def _mock_secrets(tmp_path, monkeypatch):
-    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
-    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+def _mock_tokens(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._TOKENS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._TOKENS_DIR", str(tmp_path))
     (tmp_path / "bridge_as_token.txt").write_text("fake-as-token")
 
 
@@ -36,7 +36,7 @@ def _make_client(config):
     app.dependency_overrides.clear()
 
 
-@pytest.mark.usefixtures("_mock_secrets")
+@pytest.mark.usefixtures("_mock_tokens")
 class TestBodySizeLimit:
     def test_body_at_limit_is_accepted(self):
         """A 1 MB body must not be rejected with 413."""

--- a/tests/test_healthy_matrix.py
+++ b/tests/test_healthy_matrix.py
@@ -12,9 +12,9 @@ from matrix_webhook_bridge.server import _get_config, app
 
 
 @pytest.fixture
-def _mock_secrets(tmp_path, monkeypatch):
-    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
-    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+def _mock_tokens(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._TOKENS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._TOKENS_DIR", str(tmp_path))
     (tmp_path / "bridge_as_token.txt").write_text("fake-as-token")
 
 
@@ -37,7 +37,7 @@ def _make_client(config):
     app.dependency_overrides.clear()
 
 
-@pytest.mark.usefixtures("_mock_secrets")
+@pytest.mark.usefixtures("_mock_tokens")
 class TestHealthyMatrix:
     def test_reachable_returns_200(self):
         config = _make_config()

--- a/tests/test_pre_flight_check.py
+++ b/tests/test_pre_flight_check.py
@@ -7,9 +7,9 @@ from matrix_webhook_bridge.server import _pre_flight_check
 
 
 @pytest.fixture
-def secrets_dir(tmp_path, monkeypatch):
-    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
-    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+def tokens_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._TOKENS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._TOKENS_DIR", str(tmp_path))
     return tmp_path
 
 
@@ -22,30 +22,30 @@ def _make_config(default_user: str = "bridge") -> Config:
     )
 
 
-def test_raises_when_default_user_token_missing(secrets_dir):
+def test_raises_when_default_user_token_missing(tokens_dir):
     with pytest.raises(RuntimeError, match="bridge"):
         _pre_flight_check(_make_config())
 
 
-def test_passes_when_default_user_token_present(secrets_dir):
-    (secrets_dir / "bridge_as_token.txt").write_text("tok")
+def test_passes_when_default_user_token_present(tokens_dir):
+    (tokens_dir / "bridge_as_token.txt").write_text("tok")
     _pre_flight_check(_make_config())
 
 
-def test_uses_configured_default_user(secrets_dir):
-    (secrets_dir / "custom_as_token.txt").write_text("tok")
+def test_uses_configured_default_user(tokens_dir):
+    (tokens_dir / "custom_as_token.txt").write_text("tok")
     _pre_flight_check(_make_config(default_user="custom"))
 
 
-def test_raises_for_custom_default_user_without_token(secrets_dir):
-    (secrets_dir / "bridge_as_token.txt").write_text("tok")
+def test_raises_for_custom_default_user_without_token(tokens_dir):
+    (tokens_dir / "bridge_as_token.txt").write_text("tok")
     with pytest.raises(RuntimeError, match="custom"):
         _pre_flight_check(_make_config(default_user="custom"))
 
 
-def test_warns_on_misnamed_secret_file(secrets_dir, caplog):
-    (secrets_dir / "bridge_as_token.txt").write_text("tok")
-    (secrets_dir / "unexpected.txt").write_text("x")
+def test_warns_on_misnamed_secret_file(tokens_dir, caplog):
+    (tokens_dir / "bridge_as_token.txt").write_text("tok")
+    (tokens_dir / "unexpected.txt").write_text("x")
     with caplog.at_level(logging.WARNING, logger="matrix_webhook_bridge.server"):
         _pre_flight_check(_make_config())
     assert any("unexpected.txt" in r.getMessage() for r in caplog.records)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,7 +7,12 @@ import pytest
 from starlette.testclient import TestClient
 
 from matrix_webhook_bridge.config import Config
-from matrix_webhook_bridge.server import _get_config, _pre_flight_check, app, resolve_rooms
+from matrix_webhook_bridge.server import (
+    _get_config,
+    _pre_flight_check,
+    app,
+    resolve_rooms,
+)
 
 
 def _make_config(**kwargs) -> Config:
@@ -30,9 +35,9 @@ def _make_client(config):
 
 
 @pytest.fixture
-def _mock_secrets(tmp_path, monkeypatch):
-    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
-    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+def _mock_tokens(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._TOKENS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._TOKENS_DIR", str(tmp_path))
     (tmp_path / "bridge_as_token.txt").write_text("fake-as-token")
 
 
@@ -62,7 +67,7 @@ class TestResolveRooms:
         assert resolve_rooms("svc", None, config) == ["!default:example.com"]
 
 
-@pytest.mark.usefixtures("_mock_secrets")
+@pytest.mark.usefixtures("_mock_tokens")
 class TestNotifyMultiRoom:
     def test_room_param_routes_to_specified_room(self):
         config = _make_config()
@@ -106,22 +111,22 @@ class TestNotifyMultiRoom:
 
 class TestPreFlightServiceRooms:
     @pytest.fixture
-    def secrets_dir(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
-        monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+    def tokens_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("matrix_webhook_bridge.matrix._TOKENS_DIR", str(tmp_path))
+        monkeypatch.setattr("matrix_webhook_bridge.server._TOKENS_DIR", str(tmp_path))
         (tmp_path / "bridge_as_token.txt").write_text("tok")
         return tmp_path
 
-    def test_accepts_valid_service_rooms(self, secrets_dir):
+    def test_accepts_valid_service_rooms(self, tokens_dir):
         config = _make_config(service_rooms={"svc": ["!room1:example.com", "!room2:example.com"]})
         _pre_flight_check(config)
 
-    def test_rejects_invalid_room_id_format(self, secrets_dir):
+    def test_rejects_invalid_room_id_format(self, tokens_dir):
         config = _make_config(service_rooms={"svc": ["not-a-room-id"]})
         with pytest.raises(RuntimeError, match="Invalid room_id"):
             _pre_flight_check(config)
 
-    def test_rejects_room_id_without_exclamation(self, secrets_dir):
+    def test_rejects_room_id_without_exclamation(self, tokens_dir):
         config = _make_config(service_rooms={"svc": ["room:example.com"]})
         with pytest.raises(RuntimeError, match="Invalid room_id"):
             _pre_flight_check(config)

--- a/tests/test_user_validation.py
+++ b/tests/test_user_validation.py
@@ -7,9 +7,9 @@ from matrix_webhook_bridge.server import _pre_flight_check
 
 
 @pytest.fixture
-def secrets_dir(tmp_path, monkeypatch):
-    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
-    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+def tokens_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._TOKENS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._TOKENS_DIR", str(tmp_path))
     return tmp_path
 
 
@@ -22,16 +22,16 @@ def _base_config(**kwargs) -> Config:
     )
 
 
-def test_pre_flight_check_validates_default_user(secrets_dir):
+def test_pre_flight_check_validates_default_user(tokens_dir):
     """Pre-flight check should reject invalid default_user to prevent path traversal."""
     config = _base_config(default_user="../secret")
     with pytest.raises(RuntimeError, match="Invalid default_user"):
         _pre_flight_check(config)
 
 
-def test_pre_flight_check_accepts_valid_default_user(secrets_dir):
+def test_pre_flight_check_accepts_valid_default_user(tokens_dir):
     """Pre-flight check should accept valid default_user."""
-    (secrets_dir / "bridge_as_token.txt").write_text("tok")
+    (tokens_dir / "bridge_as_token.txt").write_text("tok")
     config = _base_config(default_user="bridge")
     _pre_flight_check(config)
 
@@ -48,9 +48,9 @@ def test_pre_flight_check_accepts_valid_default_user(secrets_dir):
         "user@domain",
     ],
 )
-def test_pre_flight_rejects_invalid_service_user(secrets_dir, user):
+def test_pre_flight_rejects_invalid_service_user(tokens_dir, user):
     """Pre-flight check should reject invalid service_users localparts."""
-    (secrets_dir / "bridge_as_token.txt").write_text("tok")
+    (tokens_dir / "bridge_as_token.txt").write_text("tok")
     config = _base_config(service_users={"mysvc": user})
     with pytest.raises(RuntimeError, match="Invalid user"):
         _pre_flight_check(config)
@@ -68,8 +68,8 @@ def test_pre_flight_rejects_invalid_service_user(secrets_dir, user):
         "bot123",
     ],
 )
-def test_pre_flight_accepts_valid_service_users(secrets_dir, user):
+def test_pre_flight_accepts_valid_service_users(tokens_dir, user):
     """Pre-flight check should accept valid service_users localparts."""
-    (secrets_dir / "bridge_as_token.txt").write_text("tok")
+    (tokens_dir / "bridge_as_token.txt").write_text("tok")
     config = _base_config(service_users={"mysvc": user})
     _pre_flight_check(config)

--- a/tests/test_webhook_auth.py
+++ b/tests/test_webhook_auth.py
@@ -11,10 +11,10 @@ from matrix_webhook_bridge.server import _get_config, app
 
 
 @pytest.fixture
-def _mock_secrets(tmp_path, monkeypatch):
-    """Create a fake secrets dir with a bridge token."""
-    monkeypatch.setattr("matrix_webhook_bridge.matrix._SECRETS_DIR", str(tmp_path))
-    monkeypatch.setattr("matrix_webhook_bridge.server._SECRETS_DIR", str(tmp_path))
+def _mock_tokens(tmp_path, monkeypatch):
+    """Create a fake tokens dir with a bridge token."""
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._TOKENS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._TOKENS_DIR", str(tmp_path))
     (tmp_path / "bridge_as_token.txt").write_text("fake-as-token")
 
 
@@ -43,7 +43,7 @@ def _make_client(config):
     app.dependency_overrides.clear()
 
 
-@pytest.mark.usefixtures("_mock_secrets", "_mock_notify")
+@pytest.mark.usefixtures("_mock_tokens", "_mock_notify")
 class TestWebhookAuth:
     def test_no_secret_allows_all(self):
         """Without webhook_secret, requests need no auth."""


### PR DESCRIPTION
- Move appservice token mount point from `/run/secrets` to `/tokens` to free up `/run/secrets` for native Docker secrets in future features
- Rename `_SECRETS_DIR` → `_TOKENS_DIR` throughout source, tests, and docs
- Update `docker-compose.yml`, `Dockerfile`, `install.sh`, and all documentation accordingly
- Update `.gitignore`