### PR TITLE
feat(config): load webhook_secret from Docker secret

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,5 +93,24 @@ Clients must then include the header:
 Authorization: Bearer my-secret-token
 ```
 
+Alternatively, provide the secret via a Docker secret mounted at `/run/secrets/webhook_secret`.
+This takes precedence over the config value:
+
+```shell
+echo "my-secret-token" > secrets/webhook_secret.txt
+```
+
+```yaml
+# docker-compose.yml
+secrets:
+  webhook_secret:
+    file: ./secrets/webhook_secret.txt
+
+services:
+  bridge:
+    secrets:
+      - webhook_secret
+```
+
 Requests with a missing or incorrect token receive `401 Unauthorized`.
 The health-check endpoint (`GET /healthy`) is never authenticated.

--- a/bridge.yml.example
+++ b/bridge.yml.example
@@ -27,6 +27,8 @@ server:
   # Optional shared secret for incoming webhook authentication.
   # When set, all POST requests must include an Authorization header:
   #   Authorization: Bearer <webhook_secret>
+  # webhook_secret can also be provided via Docker secret at
+  # /run/secrets/webhook_secret (takes precedence over this value).
   # webhook_secret: your-secret-here
 
   # Map each ?service= value to the Matrix user localpart that should send the message.

--- a/matrix_webhook_bridge/config_loader.py
+++ b/matrix_webhook_bridge/config_loader.py
@@ -1,5 +1,6 @@
 """Configuration loader for YAML-based configuration."""
 
+import logging
 from pathlib import Path
 
 import jsonschema
@@ -89,6 +90,10 @@ CONFIG_SCHEMA = {
     "additionalProperties": False,
 }
 
+logger = logging.getLogger(__name__)
+
+_SECRETS_DIR = "/run/secrets"
+
 
 class ConfigError(Exception):
     """Configuration loading or validation error."""
@@ -133,8 +138,8 @@ def load_config_from_yaml(path: str) -> Config:
     matrix_section = data["matrix"]
     server_section = data.get("server", {})
 
-    # Construct and return Config instance
-    return Config(
+    # Construct Config instance
+    config: Config = Config(
         base_url=matrix_section["base_url"],
         room_id=matrix_section["room_id"],
         domain=matrix_section["domain"],
@@ -146,3 +151,23 @@ def load_config_from_yaml(path: str) -> Config:
         service_rooms=server_section.get("service_rooms", {}),
         autojoin=matrix_section.get("autojoin", False),
     )
+
+    # Docker secret takes precedence over config value
+    secret_path = Path(_SECRETS_DIR) / "webhook_secret"
+    if secret_path.is_file():
+        value = secret_path.read_text().strip()
+        if value:
+            if config.webhook_secret:
+                logger.warning(
+                    "Docker secret at %s takes precedence over webhook_secret in config.",
+                    secret_path,
+                )
+            config.webhook_secret = value
+            logger.info("webhook_secret loaded from Docker secret at %s.", secret_path)
+        else:
+            logger.warning(
+                "webhook_secret Docker secret at %s is empty — ignoring, falling back to config.",
+                secret_path,
+            )
+
+    return config

--- a/tests/test_webhook_secret_resolution.py
+++ b/tests/test_webhook_secret_resolution.py
@@ -1,0 +1,95 @@
+import logging
+
+import pytest
+
+from matrix_webhook_bridge.config_loader import load_config_from_yaml
+
+
+@pytest.fixture
+def config_file(tmp_path):
+    """Minimal valid config file."""
+
+    def _write(webhook_secret=None):
+        secret_block = f"server:\n  webhook_secret: {webhook_secret}\n" if webhook_secret else ""
+        (tmp_path / "bridge.yml").write_text(
+            f"matrix:\n"
+            f"  base_url: https://matrix.example.com\n"
+            f"  room_id: '!room:example.com'\n"
+            f"  domain: example.com\n"
+            f"{secret_block}"
+        )
+        return str(tmp_path / "bridge.yml")
+
+    return _write
+
+
+@pytest.fixture
+def secrets_dir(tmp_path, monkeypatch):
+    d = tmp_path / "secrets"
+    d.mkdir()
+    monkeypatch.setattr("matrix_webhook_bridge.config_loader._SECRETS_DIR", str(d))
+    return d
+
+
+def test_config_value_used_when_no_secret_file(config_file, secrets_dir):
+    path = config_file(webhook_secret="config-secret")
+    config = load_config_from_yaml(path)
+    assert config.webhook_secret == "config-secret"  # pragma: allowlist secret
+
+
+def test_secret_file_used_when_no_config_value(config_file, secrets_dir):
+    (secrets_dir / "webhook_secret").write_text("file-secret")
+    path = config_file()
+    config = load_config_from_yaml(path)
+    assert config.webhook_secret == "file-secret"  # pragma: allowlist secret
+
+
+def test_secret_file_wins_over_config_value(config_file, secrets_dir):
+    (secrets_dir / "webhook_secret").write_text("file-secret")
+    path = config_file(webhook_secret="config-secret")
+    config = load_config_from_yaml(path)
+    assert config.webhook_secret == "file-secret"  # pragma: allowlist secret
+
+
+def test_empty_secret_file_falls_through_to_config(config_file, secrets_dir):
+    (secrets_dir / "webhook_secret").write_text("   ")
+    path = config_file(webhook_secret="config-secret")
+    config = load_config_from_yaml(path)
+    assert config.webhook_secret == "config-secret"  # pragma: allowlist secret
+
+
+def test_neither_source_set_gives_none(config_file, secrets_dir):
+    path = config_file()
+    config = load_config_from_yaml(path)
+    assert config.webhook_secret is None
+
+
+def test_warns_when_secret_file_overrides_config(config_file, secrets_dir, caplog):
+    (secrets_dir / "webhook_secret").write_text("file-secret")
+    path = config_file(webhook_secret="config-secret")
+    with caplog.at_level(logging.WARNING, logger="matrix_webhook_bridge.config_loader"):
+        load_config_from_yaml(path)
+    assert any("takes precedence" in r.getMessage() for r in caplog.records)
+
+
+def test_warns_when_secret_file_is_empty(config_file, secrets_dir, caplog):
+    (secrets_dir / "webhook_secret").write_text("")
+    path = config_file(webhook_secret="config-secret")
+    with caplog.at_level(logging.WARNING, logger="matrix_webhook_bridge.config_loader"):
+        load_config_from_yaml(path)
+    assert any("empty" in r.getMessage() for r in caplog.records)
+
+
+def test_info_logged_when_secret_file_loaded(config_file, secrets_dir, caplog):
+    (secrets_dir / "webhook_secret").write_text("file-secret")
+    path = config_file()
+    with caplog.at_level(logging.INFO, logger="matrix_webhook_bridge.config_loader"):
+        load_config_from_yaml(path)
+    assert any("loaded from Docker secret" in r.getMessage() for r in caplog.records)
+
+
+def test_secret_file_value_is_stripped(config_file, secrets_dir):
+    (secrets_dir / "webhook_secret").write_text("  file-secret\n")
+    path = config_file()
+    config = load_config_from_yaml(path)
+    assert config.webhook_secret == "file-secret"  # pragma: allowlist secret


### PR DESCRIPTION
- Load `webhook_secret` from `/run/secrets/webhook_secret` with Docker secret taking precedence over `bridge.yml`
- Warn when the config value is overridden or the secret file is empty; info-log on successful load

Closes #78