### PR TITLE
fix(server): pass log_config=None to uvicorn.run for JSON log unification

### DIFF
--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -298,4 +298,9 @@ async def notify(
 def run_server(config: Config) -> None:
     app.state.config = config
     logger.info(f"Starting Matrix notifier server on port {config.port}...")
-    uvicorn.run(app, host="", port=config.port, access_log=False)
+    # log_config=None: skip uvicorn's own dictConfig() call so the
+    # uvicorn.* loggers propagate to root and pick up the JSON formatter,
+    # instead of emitting plain-text startup lines alongside JSON app lines.
+    uvicorn.run(
+        app, host="", port=config.port, access_log=False, log_config=None
+    )

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -298,9 +298,6 @@ async def notify(
 def run_server(config: Config) -> None:
     app.state.config = config
     logger.info(f"Starting Matrix notifier server on port {config.port}...")
-    # log_config=None: skip uvicorn's own dictConfig() call so the
-    # uvicorn.* loggers propagate to root and pick up the JSON formatter,
-    # instead of emitting plain-text startup lines alongside JSON app lines.
     uvicorn.run(
         app, host="", port=config.port, access_log=False, log_config=None
     )


### PR DESCRIPTION
Closes #84.

\`uvicorn.run()\` calls its own \`dictConfig()\` internally, which attaches a plain-text handler to the \`uvicorn.*\` loggers and bypasses the root logger's JSON formatter. The result is mixed output where app log lines are JSON and the uvicorn startup lines are plain text.

Passing \`log_config=None\` tells uvicorn to skip its \`dictConfig()\` call so the \`uvicorn.*\` loggers propagate to root and pick up the JSON formatter the rest of the app uses.

Verified locally:
- \`pre-commit run --files matrix_webhook_bridge/server.py\` clean (mypy, bandit, codespell, etc.)
- \`from matrix_webhook_bridge import server\` imports cleanly