### PR TITLE
feat(integrations): add smoketest for alertmanager

### DIFF
--- a/integrations/alertmanager-test/README.md
+++ b/integrations/alertmanager-test/README.md
@@ -1,0 +1,120 @@
+# Alertmanager smoke test for matrix-webhook-bridge
+
+A script that runs a nightly end-to-end connectivity check for the
+Alertmanager → `matrix-webhook-bridge` → Matrix pipeline.
+
+At 04:00 the script fires a test alert against the Alertmanager API, waits
+for Alertmanager to forward it to the bridge, then verifies that the bridge's
+`bridge_notify_success_total` counter increased. The alert is resolved
+immediately afterwards. If the counter did not increase the script exits with
+status 1, which systemd records as a failed unit.
+
+## Assumptions
+
+- Alertmanager is reachable at `http://localhost:9093` (configurable via
+  `ALERTMANAGER_URL`). It may run natively or as a container with the API
+  port exposed on the host.
+- `matrix-webhook-bridge` is reachable at `http://localhost:5001`
+  (configurable via `MATRIX_WEBHOOK_BRIDGE_URL`).
+- Alertmanager has a receiver that routes `severity=critical` alerts to
+  `matrix-webhook-bridge` at `POST /notify?service=alertmanager`. The test
+  alert carries `severity: critical`; if your routing rules use a different
+  label or value, adjust the `_TEST_LABELS` dict in the script accordingly.
+- `WAIT_SECONDS` (default `20`) must be at least as large as the
+  `group_wait` value in your Alertmanager route config. Increase it if
+  Alertmanager is slow to flush.
+- The bridge exposes Prometheus metrics at `GET /metrics` on the same port
+  as the webhook endpoint (enabled by default, no authentication required).
+  The script uses these metrics for end-to-end verification; if `/metrics`
+  is unavailable the check is skipped and the script exits 0.
+- If `server.webhook_secret` is set on the bridge, Alertmanager must supply
+  the secret via the `Authorization` header in its webhook config. The smoke
+  test script calls Alertmanager only, not the bridge directly, so no secret
+  configuration is needed here.
+
+## Add a Matrix Application Service
+
+Follow the instructions in the [MATRIX.md](../../MATRIX.md) guide to set up
+a Matrix Application Service for Alertmanager and invite the bot user to a
+room on your Synapse server.
+
+## Setup
+
+Copy the script and systemd units to the appropriate locations and make the
+script executable:
+
+```bash
+curl \
+  -L https://raw.githubusercontent.com/krahlos/matrix-webhook-bridge/main/integrations/alertmanager-test/alertmanager-test.py \
+  -o /usr/local/bin/alertmanager-test.py
+chmod +x /usr/local/bin/alertmanager-test.py
+
+curl \
+  -L https://raw.githubusercontent.com/krahlos/matrix-webhook-bridge/main/integrations/alertmanager-test/alertmanager-test.service \
+  -o /etc/systemd/system/alertmanager-test.service
+
+curl \
+  -L https://raw.githubusercontent.com/krahlos/matrix-webhook-bridge/main/integrations/alertmanager-test/alertmanager-test.timer \
+  -o /etc/systemd/system/alertmanager-test.timer
+```
+
+Then enable and start the timer:
+
+```bash
+systemctl daemon-reload
+systemctl enable --now alertmanager-test.timer
+```
+
+The timer defaults to `04:00` daily. To change the schedule, override the
+timer:
+
+```bash
+systemctl edit alertmanager-test.timer
+```
+
+```ini
+[Timer]
+OnCalendar=
+OnCalendar=03:30
+```
+
+To run the test immediately:
+
+```bash
+systemctl start alertmanager-test.service
+journalctl -u alertmanager-test.service
+```
+
+## Configuration
+
+| Variable                    | Default                 | Description                                      |
+| --------------------------- | ----------------------- | ------------------------------------------------ |
+| `ALERTMANAGER_URL`          | `http://localhost:9093` | Alertmanager base URL                            |
+| `MATRIX_WEBHOOK_BRIDGE_URL` | `http://localhost:5001` | Bridge base URL (used for metric verification)   |
+| `WAIT_SECONDS`              | `20`                    | Seconds to wait after firing before verifying    |
+
+## Example Notifications
+
+The test produces two Matrix messages per run — one when the alert fires and
+one when it resolves.
+
+Firing:
+
+```text
+🔥 [CRITICAL] Alertmanager smoke test (since 2026-04-26T04:00:01.054Z)
+Nightly connectivity check — safe to ignore.
+Since: 2026-04-26T04:00:01.054Z
+View in Alertmanager
+```
+
+Resolved:
+
+```text
+✅ [CRITICAL] Alertmanager smoke test (since 2026-04-26T04:00:01.054Z)
+Nightly connectivity check — safe to ignore.
+Since: 2026-04-26T04:00:01.054Z
+View in Alertmanager
+```
+
+The "View in Alertmanager" link appears when `--web.external-url` is set in
+Alertmanager's startup flags.

--- a/integrations/alertmanager-test/alertmanager-test.py
+++ b/integrations/alertmanager-test/alertmanager-test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Nightly smoke test: fires a test alert through Alertmanager and verifies
+matrix-webhook-bridge received it.
+"""
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime, timedelta
+
+_STDLIB_ATTRS = frozenset(
+    {
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "taskName",
+        "message",
+    }
+)
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        ct = time.localtime(record.created)
+        tz = time.strftime("%z", ct)
+        ts = f"{time.strftime('%Y-%m-%dT%H:%M:%S', ct)}.{int(record.msecs):03d}{tz}"
+        entry: dict = {
+            "ts": ts,
+            "level": record.levelname.lower(),
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        if record.exc_info:
+            entry["exc"] = self.formatException(record.exc_info)
+        extra = {
+            k: v
+            for k, v in record.__dict__.items()
+            if k not in _STDLIB_ATTRS and not k.startswith("_")
+        }
+        if extra:
+            entry.update(extra)
+        return json.dumps(entry, default=str)
+
+
+_handler = logging.StreamHandler()
+_handler.setFormatter(_JsonFormatter())
+logging.basicConfig(level=logging.INFO, handlers=[_handler])
+logger = logging.getLogger("alertmanager-test")
+
+ALERTMANAGER_URL = os.environ.get("ALERTMANAGER_URL", "http://localhost:9093")
+MATRIX_WEBHOOK_BRIDGE_URL = os.environ.get("MATRIX_WEBHOOK_BRIDGE_URL", "http://localhost:5001")
+WAIT_SECONDS = int(os.environ.get("WAIT_SECONDS", "20"))
+
+_TEST_LABELS = {
+    "alertname": "SmokeTest",
+    "severity": "critical",
+    "service": "alertmanager-test",
+}
+
+
+def _post(url: str, payload: list | dict) -> None:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    urllib.request.urlopen(req, timeout=10)  # nosec B310  # URL sourced from config
+
+
+def _read_metric(name: str, labels: dict[str, str]) -> float:
+    """Return a single counter value from the bridge /metrics endpoint, or 0 on failure."""
+    try:
+        with urllib.request.urlopen(  # nosec B310  # URL sourced from config
+            f"{MATRIX_WEBHOOK_BRIDGE_URL}/metrics", timeout=10
+        ) as resp:
+            for line in resp.read().decode().splitlines():
+                if line.startswith(name) and all(f'{k}="{v}"' in line for k, v in labels.items()):
+                    return float(line.rsplit(" ", 1)[-1])
+    except Exception as exc:
+        logger.warning("Could not read bridge metrics: %s", exc)
+    return 0.0
+
+
+def fire_alert() -> None:
+    payload = [
+        {
+            "labels": _TEST_LABELS,
+            "annotations": {
+                "summary": "Alertmanager smoke test",
+                "description": "Nightly connectivity check — safe to ignore.",
+            },
+        }
+    ]
+    _post(f"{ALERTMANAGER_URL}/api/v2/alerts", payload)
+    logger.info("Test alert fired.")
+
+
+def resolve_alert() -> None:
+    ends_at = (datetime.now(UTC) - timedelta(seconds=60)).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    payload = [{"labels": _TEST_LABELS, "endsAt": ends_at}]
+    _post(f"{ALERTMANAGER_URL}/api/v2/alerts", payload)
+    logger.info("Test alert resolved.")
+
+
+def main() -> None:
+    before = _read_metric("bridge_notify_success_total", {"service": "alertmanager"})
+    logger.info("bridge_notify_success_total before: %s", before)
+
+    fire_alert()
+
+    logger.info("Waiting %s seconds for Alertmanager to fire webhook...", WAIT_SECONDS)
+    time.sleep(WAIT_SECONDS)
+
+    resolve_alert()
+
+    after = _read_metric("bridge_notify_success_total", {"service": "alertmanager"})
+    logger.info("bridge_notify_success_total after: %s", after)
+
+    if after > before:
+        logger.info("Smoke test passed: matrix-webhook-bridge received the alert.")
+    else:
+        logger.error(
+            "Smoke test failed: matrix-webhook-bridge metric did not increase "
+            "(before=%s after=%s). Check Alertmanager routing and bridge connectivity.",
+            before,
+            after,
+        )
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/alertmanager-test/alertmanager-test.service
+++ b/integrations/alertmanager-test/alertmanager-test.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nightly Alertmanager smoke test via matrix-webhook-bridge
+Documentation=https://github.com/krahlos/matrix-webhook-bridge
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/alertmanager-test.py
+Environment=ALERTMANAGER_URL=http://localhost:9093
+Environment=MATRIX_WEBHOOK_BRIDGE_URL=http://localhost:5001
+Environment=WAIT_SECONDS=20

--- a/integrations/alertmanager-test/alertmanager-test.timer
+++ b/integrations/alertmanager-test/alertmanager-test.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly Alertmanager smoke test
+Requires=alertmanager-test.service
+
+[Timer]
+OnCalendar=04:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Adds a script that runs a nightly end-to-end connectivity check for the Alertmanager → `matrix-webhook-bridge` → Matrix pipeline.