### PR TITLE
ci(github): add self-assign workflow via .take comment

### DIFF
--- a/.github/workflows/self_assign.yml
+++ b/.github/workflows/self_assign.yml
@@ -1,0 +1,29 @@
+---
+
+name: Self Assign
+run-name: >-
+  Self Assign · Comment on Issue #${{ github.event.issue.number }}
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    if: contains(github.event.comment.body, '.take')
+    steps:
+      - name: Assign the user
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.payload.issue.assignees.length > 0) {
+              return core.setFailed('❌ Issue already has an assignee');
+            }
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [context.payload.comment.user.login]
+            });
+            core.notice(`🎯 Assigned to ${context.payload.comment.user.login}`);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,12 @@ Contributions are welcome — no approval needed to get started.
 ## Picking up work
 
 - **Existing issues**: If an issue has no assignee and you want to work on it
-  just assign it to yourself and start working.
+  just comment `.take` and the bot will assign it to you. [^1]
 - **New features**: Create an issue describing what you want to add, then start
   implementing. No need to wait for a response before opening a draft PR.
+
+[^1]: GitHub does not allow non-maintainers to assign issues, so the bot has to
+      do it for you. See `.github/workflows/self_assign.yml` for details.
 
 ## Guidelines
 


### PR DESCRIPTION
- Add `.take` comment command to self-assign issues (workaround for GitHub's non-maintainer assignment restriction)
- Update `CONTRIBUTING.md`