### PR TITLE
fix: escape Alertmanager HTML fields

### DIFF
--- a/matrix_webhook_bridge/formatters/alertmanager.py
+++ b/matrix_webhook_bridge/formatters/alertmanager.py
@@ -1,3 +1,6 @@
+from html import escape
+
+
 def format_alertmanager(data: dict) -> list[tuple[str, str]]:
     """Format an Alertmanager webhook payload to a Matrix message."""
     out = []
@@ -14,12 +17,16 @@ def format_alertmanager(data: dict) -> list[tuple[str, str]]:
         plain = f"{icon} [{severity}] {summary}"
         if starts_at:
             plain += f" (since {starts_at})"
-        html = f'<b><font color="{color}">{icon} [{severity}] {summary}</font></b>'
+
+        escaped_severity = escape(severity)
+        escaped_summary = escape(summary)
+        html = f'<b><font color="{color}">{icon} [{escaped_severity}] {escaped_summary}</font></b>'
         if desc:
-            html += f"<br/><i>{desc}</i>"
+            html += f"<br/><i>{escape(desc)}</i>"
         if starts_at:
-            html += f"<br/>Since: {starts_at}"
+            html += f"<br/>Since: {escape(starts_at)}"
         if fingerprint and external_url:
-            html += f'<br/><a href="{external_url}/#/alerts?fingerprint={fingerprint}">View in Alertmanager</a>'
+            href = escape(f"{external_url}/#/alerts?fingerprint={fingerprint}", quote=True)
+            html += f'<br/><a href="{href}">View in Alertmanager</a>'
         out.append((plain, html))
     return out

--- a/matrix_webhook_bridge/formatters/alertmanager.py
+++ b/matrix_webhook_bridge/formatters/alertmanager.py
@@ -20,13 +20,16 @@ def format_alertmanager(data: dict) -> list[tuple[str, str]]:
 
         escaped_severity = escape(severity)
         escaped_summary = escape(summary)
+        escaped_desc = escape(desc)
+        escaped_starts_at = escape(starts_at)
+        escaped_href = escape(f"{external_url}/#/alerts?fingerprint={fingerprint}", quote=True)
+
         html = f'<b><font color="{color}">{icon} [{escaped_severity}] {escaped_summary}</font></b>'
         if desc:
-            html += f"<br/><i>{escape(desc)}</i>"
+            html += f"<br/><i>{escaped_desc}</i>"
         if starts_at:
-            html += f"<br/>Since: {escape(starts_at)}"
+            html += f"<br/>Since: {escaped_starts_at}"
         if fingerprint and external_url:
-            href = escape(f"{external_url}/#/alerts?fingerprint={fingerprint}", quote=True)
-            html += f'<br/><a href="{href}">View in Alertmanager</a>'
+            html += f'<br/><a href="{escaped_href}">View in Alertmanager</a>'
         out.append((plain, html))
     return out

--- a/tests/test_alertmanager_formatter.py
+++ b/tests/test_alertmanager_formatter.py
@@ -1,3 +1,5 @@
+import re
+
 from matrix_webhook_bridge.formatters.alertmanager import format_alertmanager
 
 
@@ -18,6 +20,7 @@ def test_format_alertmanager_preserves_plain_text_message():
     [(plain, html)] = format_alertmanager(payload)
 
     assert plain == "🔥 [CRITICAL] Disk nearly full (since 2026-05-02T00:00:00Z)"
+    assert "2026-05-02T00:00:00Z" in plain
     assert "Disk nearly full" in html
     assert "Only 5% left" in html
     assert 'href="https://alerts.example/#/alerts?fingerprint=abc123"' in html
@@ -53,5 +56,9 @@ def test_format_alertmanager_escapes_html_and_href_values():
     assert '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;' in html
     assert '&lt;b onclick=&quot;alert(2)&quot;&gt;details&lt;/b&gt;' in html
     assert '&lt;time onmouseover=&quot;alert(3)&quot;&gt;now&lt;/time&gt;' in html
-    assert 'href="https://alerts.example/?q=&quot; onclick=&quot;alert(1)' in html
-    assert 'fingerprint=abc&quot; onclick=&quot;alert(4)"' in html
+    href_match = re.search(r'<a href="([^"]*)">', html)
+    assert href_match is not None
+    assert href_match.group(1) == (
+        "https://alerts.example/?q=&quot; onclick=&quot;alert(1)"
+        "/#/alerts?fingerprint=abc&quot; onclick=&quot;alert(4)"
+    )

--- a/tests/test_alertmanager_formatter.py
+++ b/tests/test_alertmanager_formatter.py
@@ -1,0 +1,57 @@
+from matrix_webhook_bridge.formatters.alertmanager import format_alertmanager
+
+
+def test_format_alertmanager_preserves_plain_text_message():
+    payload = {
+        "externalURL": "https://alerts.example",
+        "alerts": [
+            {
+                "status": "firing",
+                "labels": {"alertname": "DiskFull", "severity": "critical"},
+                "annotations": {"summary": "Disk nearly full", "description": "Only 5% left"},
+                "startsAt": "2026-05-02T00:00:00Z",
+                "fingerprint": "abc123",
+            }
+        ],
+    }
+
+    [(plain, html)] = format_alertmanager(payload)
+
+    assert plain == "🔥 [CRITICAL] Disk nearly full (since 2026-05-02T00:00:00Z)"
+    assert "Disk nearly full" in html
+    assert "Only 5% left" in html
+    assert 'href="https://alerts.example/#/alerts?fingerprint=abc123"' in html
+
+
+def test_format_alertmanager_escapes_html_and_href_values():
+    payload = {
+        "externalURL": 'https://alerts.example/?q=" onclick="alert(1)',
+        "alerts": [
+            {
+                "status": "firing",
+                "labels": {
+                    "alertname": "Fallback",
+                    "severity": 'critical"><script>alert(1)</script>',
+                },
+                "annotations": {
+                    "summary": '<img src=x onerror="alert(1)">',
+                    "description": '<b onclick="alert(2)">details</b>',
+                },
+                "startsAt": '<time onmouseover="alert(3)">now</time>',
+                "fingerprint": 'abc" onclick="alert(4)',
+            }
+        ],
+    }
+
+    [(plain, html)] = format_alertmanager(payload)
+
+    assert '<img src=x onerror="alert(1)">' in plain
+    assert '<img src=x onerror="alert(1)">' not in html
+    assert '<b onclick="alert(2)">details</b>' not in html
+    assert '<time onmouseover="alert(3)">now</time>' not in html
+    assert 'onclick="alert' not in html
+    assert '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;' in html
+    assert '&lt;b onclick=&quot;alert(2)&quot;&gt;details&lt;/b&gt;' in html
+    assert '&lt;time onmouseover=&quot;alert(3)&quot;&gt;now&lt;/time&gt;' in html
+    assert 'href="https://alerts.example/?q=&quot; onclick=&quot;alert(1)' in html
+    assert 'fingerprint=abc&quot; onclick=&quot;alert(4)"' in html


### PR DESCRIPTION
Fixes #31

## Summary

- escape Alertmanager summary, severity, description, and startsAt before adding them to Matrix HTML
- escape the generated Alertmanager `href` attribute built from `externalURL` and `fingerprint`
- add regression tests that keep plain text unchanged while verifying malicious tags/attributes do not appear raw in HTML

## Validation

- `pytest tests/test_alertmanager_formatter.py -q`
- `pytest -q`
- `ruff check .`
