### PR TITLE
fix(autojoin): join service_users with no service_rooms to default room

### DIFF
--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -100,6 +100,9 @@ def _autojoin_all(config: Config) -> None:
     for svc, rooms in config.service_rooms.items():
         user = config.service_users.get(svc, config.default_user)
         users_rooms.setdefault(user, set()).update(rooms)
+    for svc, user in config.service_users.items():
+        if svc not in config.service_rooms:
+            users_rooms.setdefault(user, set()).add(config.room_id)
 
     for user, room_set in users_rooms.items():
         user_id = f"@{user}:{config.domain}"

--- a/tests/test_autojoin.py
+++ b/tests/test_autojoin.py
@@ -57,6 +57,13 @@ class TestAutojoinAll:
                 _autojoin_all(config)  # must not raise
         assert any("autojoin failed" in r.getMessage() for r in caplog.records)
 
+    def test_service_user_without_service_rooms_joins_default_room(self):
+        config = _cfg(service_users={"diun": "diun"})
+        with patch("matrix_webhook_bridge.server._join_room") as mock_join:
+            _autojoin_all(config)
+        called = [(c.args[3], c.args[1]) for c in mock_join.call_args_list]
+        assert ("@diun:example.com", "!default:example.com") in called
+
     def test_autojoin_false_skipped_at_lifespan(self):
         config = _cfg(autojoin=False)
         assert not config.autojoin


### PR DESCRIPTION
- fix bug where `service_users` entries with no `service_rooms` counterpart were skipped during autojoin
- add test covering the missing case 