### PR TITLE
feat: add GET /version endpoint

### DIFF
--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -195,6 +195,12 @@ def healthy(config: Config = Depends(_get_config)):
     return {"status": "ok", "uptime": uptime}
 
 
+@app.get("/version", summary="Application version", tags=["health"])
+def app_version():
+    """Return the current application version from package metadata."""
+    return {"version": version("matrix-webhook-bridge")}
+
+
 @app.get(
     "/healthy/matrix",
     summary="Matrix homeserver health check",

--- a/tests/test_version_endpoint.py
+++ b/tests/test_version_endpoint.py
@@ -1,0 +1,46 @@
+"""Tests for GET /version endpoint."""
+
+from contextlib import contextmanager
+from importlib.metadata import version
+
+import pytest
+from starlette.testclient import TestClient
+
+from matrix_webhook_bridge.config import Config
+from matrix_webhook_bridge.server import _get_config, app
+
+
+@pytest.fixture
+def _mock_tokens(tmp_path, monkeypatch):
+    monkeypatch.setattr("matrix_webhook_bridge.matrix._TOKENS_DIR", str(tmp_path))
+    monkeypatch.setattr("matrix_webhook_bridge.server._TOKENS_DIR", str(tmp_path))
+    (tmp_path / "bridge_as_token.txt").write_text("fake-as-token")
+
+
+def _make_config(**overrides) -> Config:
+    defaults = {
+        "base_url": "https://matrix.example.com",
+        "room_id": "!room:example.com",
+        "domain": "example.com",
+    }
+    defaults.update(overrides)
+    return Config(**defaults)
+
+
+@contextmanager
+def _make_client(config):
+    app.dependency_overrides[_get_config] = lambda: config
+    app.state.config = config
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.usefixtures("_mock_tokens")
+def test_version_endpoint_returns_package_version():
+    """/version returns the version from importlib.metadata so it stays in sync with pyproject."""
+    expected = version("matrix-webhook-bridge")
+    with _make_client(_make_config()) as client:
+        response = client.get("/version")
+    assert response.status_code == 200
+    assert response.json() == {"version": expected}


### PR DESCRIPTION
## Summary

Add a `GET /version` endpoint per #50 that returns the running application version, sourced from `importlib.metadata.version("matrix-webhook-bridge")`. Shape mirrors `/healthy`: `{"version": "..."}`.

## Why this matters

Issue #50 calls out that there's no observability endpoint for the deployed version. Bridges sitting behind reverse proxies often need a fast way to read the running version without parsing `pyproject.toml` or guessing from image tags; ops tools also benefit from a fixed JSON shape they can scrape next to the existing `/healthy`. Reading from `importlib.metadata` (already imported in `matrix_webhook_bridge/server.py` for the FastAPI `version` field) keeps the response in sync with the package metadata - bumping `pyproject.toml`'s `[project].version` is the only required action on release.

The new handler is wired into the existing FastAPI app under the `health` tag so the OpenAPI page groups it with `/healthy` and `/healthy/matrix`.

## Testing

- `pytest` 97 passed (96 existing + the new `tests/test_version_endpoint.py::test_version_endpoint_returns_package_version`).
- The new test mocks `_TOKENS_DIR` the same way `tests/test_healthy_matrix.py` does, hits `/version` via `TestClient`, asserts 200, and verifies the returned version equals `importlib.metadata.version("matrix-webhook-bridge")`.

Closes #50
