### PR TITLE
perf(matrix): reuse keep-alive connection per host

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,9 +69,9 @@ repos:
     rev: v2.8.0
     hooks:
       - id: pip-audit
-        args: ["--ignore-vuln", "GHSA-58qw-9mgm-455v"]
-        # GHSA-58qw-9mgm-455v (CVE-2026-3219): vulnerability in pip itself (<=26.0.1),
-        # not a project dependency. Remove once pip 26.0.2+ is available.
+        args: ["--ignore-vuln", "PYSEC-2026-196"]
+        # PYSEC-2026-196: vulnerability in pip itself (<=26.1.1), not a project
+        # dependency. Remove once the hook env picks up pip 26.1.2+.
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.7
     hooks:

--- a/matrix_webhook_bridge/matrix.py
+++ b/matrix_webhook_bridge/matrix.py
@@ -1,10 +1,13 @@
+import http.client
+import io
 import json
 import logging
+import threading
 import time
+from email.message import Message as HTTPMessage
 from functools import lru_cache
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote
-from urllib.request import Request, urlopen
+from urllib.parse import quote, urlsplit
 from uuid import uuid4
 
 VERSIONS_PATH = "/_matrix/client/versions"
@@ -22,6 +25,74 @@ def _token_path(user: str) -> str:
 @lru_cache
 def _token(path: str) -> str:
     return open(path).read().strip()
+
+
+class _KeepAliveConnection:
+    """Keep-alive HTTP(S) connection to one host, reused across requests.
+
+    Exists to avoid a TCP+TLS handshake per request, which dominated CPU
+    during notification bursts (#95). A lock serializes requests because
+    http.client connections are not thread-safe; a connection dropped by
+    the server (idle keep-alive timeout) is reopened and retried once.
+
+    ponytail: one serialized connection per host caps throughput at
+    1/RTT msg/s; switch to a small per-user connection pool if burst
+    latency ever matters.
+    """
+
+    def __init__(self, base_url: str):
+        parts = urlsplit(base_url)
+        self._cls = (
+            http.client.HTTPSConnection if parts.scheme == "https" else http.client.HTTPConnection
+        )
+        self._netloc = parts.netloc
+        self._lock = threading.Lock()
+        self._conn: http.client.HTTPConnection | None = None
+
+    def request(self, method: str, path: str, body: bytes | None, headers: dict, timeout: int):
+        with self._lock:
+            for attempt in (1, 2):
+                if self._conn is None:
+                    self._conn = self._cls(self._netloc, timeout=timeout)
+                elif self._conn.sock is not None:
+                    # http.client applies .timeout only at connect; adjust the
+                    # live socket directly for an already-open connection.
+                    self._conn.sock.settimeout(timeout)
+                try:
+                    self._conn.request(method, path, body=body, headers=headers)
+                    resp = self._conn.getresponse()
+                    return resp.status, resp.reason, resp.read()
+                except (http.client.HTTPException, OSError):
+                    self._conn.close()
+                    self._conn = None
+                    if attempt == 2:
+                        raise
+
+
+_connections: dict[str, _KeepAliveConnection] = {}
+_connections_lock = threading.Lock()
+
+
+def _connection_for(base_url: str) -> _KeepAliveConnection:
+    with _connections_lock:
+        conn = _connections.get(base_url)
+        if conn is None:
+            conn = _connections[base_url] = _KeepAliveConnection(base_url)
+        return conn
+
+
+def _do_request(
+    base_url: str, method: str, path: str, body: bytes | None, headers: dict, timeout: int
+) -> bytes:
+    """Issue an HTTP request against base_url, reusing a keep-alive connection."""
+    conn = _connection_for(base_url)
+    try:
+        status, reason, data = conn.request(method, path, body, headers, timeout)
+    except (http.client.HTTPException, OSError) as e:
+        raise URLError(e) from e
+    if status >= 400:
+        raise HTTPError(base_url + path, status, reason, HTTPMessage(), io.BytesIO(data))
+    return bytes(data)
 
 
 def _with_retry(fn):
@@ -67,24 +138,18 @@ def join_room(
     timeout: int = 5,
 ) -> None:
     """Join a Matrix room as user_id."""
-    url = (
-        f"{base_url}/_matrix/client/v3/join/{quote(room_id, safe='')}"
+    path = (
+        f"/_matrix/client/v3/join/{quote(room_id, safe='')}"
         f"?user_id={quote(user_id, safe='')}"
     )
 
     def attempt():
-        req = Request(
-            url,
-            data=b"{}",
-            method="POST",
-            headers={
-                "Authorization": f"Bearer {_token(token_file)}",
-                "Content-Type": "application/json",
-            },
-        )
+        headers = {
+            "Authorization": f"Bearer {_token(token_file)}",
+            "Content-Type": "application/json",
+        }
         logger.debug("Joining room %s as %s", room_id, user_id)
-        with urlopen(req, timeout=timeout) as r:  # nosec B310  # URL sourced from config
-            r.read()
+        _do_request(base_url, "POST", path, b"{}", headers, timeout)
         logger.info("Joined room %s as %s", room_id, user_id)
 
     _with_retry(attempt)
@@ -92,10 +157,7 @@ def join_room(
 
 def probe(base_url: str, timeout: int = 5) -> None:
     """GET /_matrix/client/versions to check homeserver reachability."""
-    url = f"{base_url}{VERSIONS_PATH}"
-    req = Request(url, method="GET")
-    with urlopen(req, timeout=timeout) as r:  # nosec B310  # URL sourced from config
-        r.read()
+    _do_request(base_url, "GET", VERSIONS_PATH, None, {}, timeout)
 
 
 def notify(
@@ -109,8 +171,8 @@ def notify(
 ) -> None:
     """Send a message to the Matrix room."""
     txn = uuid4().hex
-    url = (
-        f"{base_url}/_matrix/client/v3/rooms/{quote(room_id, safe='')}"
+    path = (
+        f"/_matrix/client/v3/rooms/{quote(room_id, safe='')}"
         f"/send/m.room.message/{txn}?user_id={quote(user_id, safe='')}"
     )
     payload = json.dumps(
@@ -123,18 +185,12 @@ def notify(
     ).encode()
 
     def attempt():
-        req = Request(
-            url,
-            data=payload,
-            method="PUT",
-            headers={
-                "Authorization": f"Bearer {_token(token_file)}",
-                "Content-Type": "application/json",
-            },
-        )
+        headers = {
+            "Authorization": f"Bearer {_token(token_file)}",
+            "Content-Type": "application/json",
+        }
         logger.debug("Sending Matrix message as %s: %s", user_id, plain)
-        with urlopen(req, timeout=timeout) as r:  # nosec B310  # URL sourced from config
-            r.read()
+        _do_request(base_url, "PUT", path, payload, headers, timeout)
         logger.info("Matrix message sent as %s", user_id)
 
     _with_retry(attempt)

--- a/matrix_webhook_bridge/matrix.py
+++ b/matrix_webhook_bridge/matrix.py
@@ -1,14 +1,14 @@
-import http.client
 import io
 import json
 import logging
-import threading
 import time
 from email.message import Message as HTTPMessage
 from functools import lru_cache
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote
 from uuid import uuid4
+
+import urllib3
 
 VERSIONS_PATH = "/_matrix/client/versions"
 
@@ -27,72 +27,25 @@ def _token(path: str) -> str:
     return open(path).read().strip()
 
 
-class _KeepAliveConnection:
-    """Keep-alive HTTP(S) connection to one host, reused across requests.
-
-    Exists to avoid a TCP+TLS handshake per request, which dominated CPU
-    during notification bursts (#95). A lock serializes requests because
-    http.client connections are not thread-safe; a connection dropped by
-    the server (idle keep-alive timeout) is reopened and retried once.
-
-    ponytail: one serialized connection per host caps throughput at
-    1/RTT msg/s; switch to a small per-user connection pool if burst
-    latency ever matters.
-    """
-
-    def __init__(self, base_url: str):
-        parts = urlsplit(base_url)
-        self._cls = (
-            http.client.HTTPSConnection if parts.scheme == "https" else http.client.HTTPConnection
-        )
-        self._netloc = parts.netloc
-        self._lock = threading.Lock()
-        self._conn: http.client.HTTPConnection | None = None
-
-    def request(self, method: str, path: str, body: bytes | None, headers: dict, timeout: int):
-        with self._lock:
-            for attempt in (1, 2):
-                if self._conn is None:
-                    self._conn = self._cls(self._netloc, timeout=timeout)
-                elif self._conn.sock is not None:
-                    # http.client applies .timeout only at connect; adjust the
-                    # live socket directly for an already-open connection.
-                    self._conn.sock.settimeout(timeout)
-                try:
-                    self._conn.request(method, path, body=body, headers=headers)
-                    resp = self._conn.getresponse()
-                    return resp.status, resp.reason, resp.read()
-                except (http.client.HTTPException, OSError):
-                    self._conn.close()
-                    self._conn = None
-                    if attempt == 2:
-                        raise
-
-
-_connections: dict[str, _KeepAliveConnection] = {}
-_connections_lock = threading.Lock()
-
-
-def _connection_for(base_url: str) -> _KeepAliveConnection:
-    with _connections_lock:
-        conn = _connections.get(base_url)
-        if conn is None:
-            conn = _connections[base_url] = _KeepAliveConnection(base_url)
-        return conn
+# Pooled keep-alive connections: avoids a TCP+TLS handshake per request,
+# which dominated CPU during notification bursts (#95). Retry(1) re-sends
+# once when the server drops an idle keep-alive connection.
+_http = urllib3.PoolManager(maxsize=4, retries=urllib3.Retry(1, backoff_factor=0))
 
 
 def _do_request(
     base_url: str, method: str, path: str, body: bytes | None, headers: dict, timeout: int
 ) -> bytes:
-    """Issue an HTTP request against base_url, reusing a keep-alive connection."""
-    conn = _connection_for(base_url)
+    """Issue an HTTP request against base_url, reusing pooled keep-alive connections."""
     try:
-        status, reason, data = conn.request(method, path, body, headers, timeout)
-    except (http.client.HTTPException, OSError) as e:
+        resp = _http.request(method, base_url + path, body=body, headers=headers, timeout=timeout)
+    except urllib3.exceptions.HTTPError as e:
         raise URLError(e) from e
-    if status >= 400:
-        raise HTTPError(base_url + path, status, reason, HTTPMessage(), io.BytesIO(data))
-    return bytes(data)
+    if resp.status >= 400:
+        raise HTTPError(
+            base_url + path, resp.status, resp.reason or "", HTTPMessage(), io.BytesIO(resp.data)
+        )
+    return bytes(resp.data)
 
 
 def _with_retry(fn):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "jsonschema>=4.0,<5.0",
     "prometheus-client>=0.20,<1.0",
     "pyyaml>=6.0,<7.0",
+    "urllib3>=2.0,<3.0",
     "uvicorn[standard]>=0.30,<1.0",
 ]
 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -11,13 +11,6 @@ import pytest
 from matrix_webhook_bridge import matrix as matrix_mod
 
 
-@pytest.fixture(autouse=True)
-def _clear_connections():
-    matrix_mod._connections.clear()
-    yield
-    matrix_mod._connections.clear()
-
-
 def test_notify_success_path(tmp_path):
     token = tmp_path / "user_as_token.txt"
     token.write_text("test-token\n")
@@ -156,28 +149,3 @@ def test_join_room_4xx_raises_immediately(tmp_path):
                 timeout=5,
             )
     assert exc_info.value.code == 403
-
-
-def test_connection_reused_across_notify_calls(tmp_path):
-    """Regression test for #95: bursts of notifies must not re-handshake per call."""
-    token = tmp_path / "user_as_token.txt"
-    token.write_text("test-token\n")
-    matrix_mod._token.cache_clear()
-
-    fake_resp = type("_Resp", (), {"status": 200, "reason": "OK", "read": lambda self: b""})()
-    with patch("http.client.HTTPSConnection") as mock_conn_cls:
-        mock_conn_cls.return_value.getresponse.return_value = fake_resp
-        for _ in range(3):
-            matrix_mod.notify(
-                base_url="https://matrix.example.org",
-                room_id="!room:example.org",
-                plain="hello",
-                html="<b>hello</b>",
-                token_file=str(token),
-                user_id="@bot:example.org",
-                timeout=5,
-            )
-
-    # One connection object for all three sends, not one per send.
-    mock_conn_cls.assert_called_once()
-    assert mock_conn_cls.return_value.request.call_count == 3

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -11,20 +11,11 @@ import pytest
 from matrix_webhook_bridge import matrix as matrix_mod
 
 
-class _FakeContextManager:
-    """Minimal context manager returning a stub response with a .read() method."""
-
-    def __init__(self):
-        self._body = b""
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc, tb):
-        return False
-
-    def read(self):
-        return self._body
+@pytest.fixture(autouse=True)
+def _clear_connections():
+    matrix_mod._connections.clear()
+    yield
+    matrix_mod._connections.clear()
 
 
 def test_notify_success_path(tmp_path):
@@ -32,7 +23,7 @@ def test_notify_success_path(tmp_path):
     token.write_text("test-token\n")
     matrix_mod._token.cache_clear()
 
-    with patch.object(matrix_mod, "urlopen", return_value=_FakeContextManager()):
+    with patch.object(matrix_mod, "_do_request", return_value=b"") as mock_request:
         matrix_mod.notify(
             base_url="https://matrix.example.org",
             room_id="!room:example.org",
@@ -42,6 +33,8 @@ def test_notify_success_path(tmp_path):
             user_id="@bot:example.org",
             timeout=5,
         )
+    mock_request.assert_called_once()
+    assert mock_request.call_args.args[1] == "PUT"
 
 
 def test_notify_http_error_includes_response_body(tmp_path, caplog):
@@ -65,7 +58,7 @@ def test_notify_http_error_includes_response_body(tmp_path, caplog):
     )
 
     caplog.set_level(logging.ERROR)
-    with patch.object(matrix_mod, "urlopen", side_effect=err):
+    with patch.object(matrix_mod, "_do_request", side_effect=err):
         with pytest.raises(HTTPError) as exc_info:
             matrix_mod.notify(
                 base_url="https://matrix.example.org",
@@ -107,7 +100,7 @@ def test_notify_http_error_unreadable_body_does_not_crash(tmp_path, caplog):
     )
 
     caplog.set_level(logging.ERROR)
-    with patch.object(matrix_mod, "urlopen", side_effect=err):
+    with patch.object(matrix_mod, "_do_request", side_effect=err):
         with pytest.raises(HTTPError):
             matrix_mod.notify(
                 base_url="https://matrix.example.org",
@@ -128,7 +121,7 @@ def test_join_room_success_path(tmp_path):
     token.write_text("test-token\n")
     matrix_mod._token.cache_clear()
 
-    with patch.object(matrix_mod, "urlopen", return_value=_FakeContextManager()):
+    with patch.object(matrix_mod, "_do_request", return_value=b"") as mock_request:
         matrix_mod.join_room(
             base_url="https://matrix.example.org",
             room_id="!room:example.org",
@@ -136,6 +129,8 @@ def test_join_room_success_path(tmp_path):
             user_id="@bot:example.org",
             timeout=5,
         )
+    mock_request.assert_called_once()
+    assert mock_request.call_args.args[1] == "POST"
 
 
 def test_join_room_4xx_raises_immediately(tmp_path):
@@ -151,7 +146,7 @@ def test_join_room_4xx_raises_immediately(tmp_path):
         fp=io.BytesIO(b'{"errcode":"M_FORBIDDEN"}'),
     )
 
-    with patch.object(matrix_mod, "urlopen", side_effect=err):
+    with patch.object(matrix_mod, "_do_request", side_effect=err):
         with pytest.raises(HTTPError) as exc_info:
             matrix_mod.join_room(
                 base_url="https://matrix.example.org",
@@ -161,3 +156,28 @@ def test_join_room_4xx_raises_immediately(tmp_path):
                 timeout=5,
             )
     assert exc_info.value.code == 403
+
+
+def test_connection_reused_across_notify_calls(tmp_path):
+    """Regression test for #95: bursts of notifies must not re-handshake per call."""
+    token = tmp_path / "user_as_token.txt"
+    token.write_text("test-token\n")
+    matrix_mod._token.cache_clear()
+
+    fake_resp = type("_Resp", (), {"status": 200, "reason": "OK", "read": lambda self: b""})()
+    with patch("http.client.HTTPSConnection") as mock_conn_cls:
+        mock_conn_cls.return_value.getresponse.return_value = fake_resp
+        for _ in range(3):
+            matrix_mod.notify(
+                base_url="https://matrix.example.org",
+                room_id="!room:example.org",
+                plain="hello",
+                html="<b>hello</b>",
+                token_file=str(token),
+                user_id="@bot:example.org",
+                timeout=5,
+            )
+
+    # One connection object for all three sends, not one per send.
+    mock_conn_cls.assert_called_once()
+    assert mock_conn_cls.return_value.request.call_count == 3

--- a/tests/test_notify_performance.py
+++ b/tests/test_notify_performance.py
@@ -1,0 +1,77 @@
+"""Guards against notify() opening a new connection on every call.
+
+Counts connect() calls via cProfile instead of measuring wall-clock time:
+counts are deterministic, a timing threshold would flake on shared CI
+runners.
+
+Checked the test can fail: clearing matrix_mod._connections before each
+notify() in the loop (forcing a fresh connection every time) turns the
+1 connect() below into 20, past MAX_CONNECTS.
+"""
+import threading
+from cProfile import Profile
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from matrix_webhook_bridge import matrix as matrix_mod
+
+N_CALLS = 20
+# 1 real connection + slack for a keep-alive timeout/reconnect under CI jitter.
+MAX_CONNECTS = 3
+
+
+class _EchoHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"  # keep-alive; default HTTP/1.0 closes per request
+
+    def do_PUT(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def log_message(self, *a):
+        pass
+
+
+@pytest.fixture
+def echo_server():
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), _EchoHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{httpd.server_port}"
+    httpd.shutdown()
+    thread.join()
+
+
+def test_notify_reuses_connection_across_burst(tmp_path, echo_server):
+    token = tmp_path / "bridge_as_token.txt"
+    token.write_text("test-token\n")
+    matrix_mod._token.cache_clear()
+    matrix_mod._connections.clear()
+
+    profiler = Profile()
+    profiler.enable()
+    for _ in range(N_CALLS):
+        matrix_mod.notify(
+            base_url=echo_server,
+            room_id="!room:example.org",
+            plain="hello",
+            html="<b>hello</b>",
+            token_file=str(token),
+            user_id="@bridge:example.org",
+            timeout=5,
+        )
+    profiler.disable()
+
+    connect_calls = sum(
+        entry.callcount
+        for entry in profiler.getstats()
+        if getattr(entry.code, "co_name", entry.code) == "connect"
+    )
+
+    assert connect_calls <= MAX_CONNECTS, (
+        f"expected at most {MAX_CONNECTS} socket connects for {N_CALLS} notify() "
+        f"calls (keep-alive reuse), got {connect_calls} — connection is being "
+        "re-established per call"
+    )

--- a/tests/test_notify_performance.py
+++ b/tests/test_notify_performance.py
@@ -4,9 +4,9 @@ Counts connect() calls via cProfile instead of measuring wall-clock time:
 counts are deterministic, a timing threshold would flake on shared CI
 runners.
 
-Checked the test can fail: clearing matrix_mod._connections before each
-notify() in the loop (forcing a fresh connection every time) turns the
-1 connect() below into 20, past MAX_CONNECTS.
+Checked the test can fail: passing headers={"Connection": "close"} in
+_do_request (forcing a fresh connection every time) turns the 1 connect()
+below into 20, past MAX_CONNECTS.
 """
 import threading
 from cProfile import Profile
@@ -48,7 +48,7 @@ def test_notify_reuses_connection_across_burst(tmp_path, echo_server):
     token = tmp_path / "bridge_as_token.txt"
     token.write_text("test-token\n")
     matrix_mod._token.cache_clear()
-    matrix_mod._connections.clear()
+    matrix_mod._http.clear()
 
     profiler = Profile()
     profiler.enable()


### PR DESCRIPTION
- `urlopen` opened a fresh TCP+TLS connection per message; alertmanager bursts fan out to
  one send per alert, so handshake cost dominated CPU on small hosts
- reuse keep-alive connections via `urllib3.PoolManager` (new runtime dependency) instead
  of a hand-rolled per-host connection cache; the pool also allows concurrent sends where
  a single cached connection would serialize them
- regression test counts socket `connect()` calls across a 20-notify burst against a
  local HTTP server, so reuse breakage fails deterministically instead of flaking on timing

Closes #95
