### PR TITLE
chore(prek): add ruff and ty hooks

### DIFF
--- a/matrix_webhook_bridge/matrix.py
+++ b/matrix_webhook_bridge/matrix.py
@@ -14,7 +14,7 @@ VERSIONS_PATH = "/_matrix/client/versions"
 
 logger = logging.getLogger(__name__)
 
-_TOKENS_DIR = "/tokens"
+_TOKENS_DIR: str = "/tokens"
 _RETRY_DELAYS = (1, 2, 4)  # seconds before attempts 2, 3, 4
 
 
@@ -91,10 +91,7 @@ def join_room(
     timeout: int = 5,
 ) -> None:
     """Join a Matrix room as user_id."""
-    path = (
-        f"/_matrix/client/v3/join/{quote(room_id, safe='')}"
-        f"?user_id={quote(user_id, safe='')}"
-    )
+    path = f"/_matrix/client/v3/join/{quote(room_id, safe='')}?user_id={quote(user_id, safe='')}"
 
     def attempt():
         headers = {

--- a/matrix_webhook_bridge/server.py
+++ b/matrix_webhook_bridge/server.py
@@ -307,6 +307,4 @@ async def notify(
 def run_server(config: Config) -> None:
     app.state.config = config
     logger.info(f"Starting Matrix notifier server on port {config.port}...")
-    uvicorn.run(
-        app, host="", port=config.port, access_log=False, log_config=None
-    )
+    uvicorn.run(app, host="", port=config.port, access_log=False, log_config=None)

--- a/prek.toml
+++ b/prek.toml
@@ -2,180 +2,148 @@
 # See https://prek.j178.dev for more information.
 #:schema https://www.schemastore.org/prek.json
 
-default_install_hook_types = [
-  "pre-commit",
-  "commit-msg",
-  "pre-push"
-  ]
+default_install_hook_types = ["pre-commit", "commit-msg", "pre-push"]
 minimum_pre_commit_version = "3.6.0"
 
 [[repos]]
 repo = "https://github.com/pre-commit/pre-commit-hooks"
 rev = "v4.4.0"
-hooks = [
-  {
-    id = "check-added-large-files",
-    args = ["--maxkb=1000"]
-  },
-  { id = "check-merge-conflict" },
-  { id = "check-toml" },
-  { id = "check-yaml" },
-  { id = "debug-statements" },
-  { id = "detect-private-key" },
-  { id = "end-of-file-fixer" },
-  {
-    id = "pretty-format-json",
-    args = [
-      "--autofix",
-      "--indent=2",
-      "--no-ensure-ascii"
-    ]
-  },
-  { id = "trailing-whitespace" }
-]
+
+[[repos.hooks]]
+id = "check-added-large-files"
+args = ["--maxkb=1000"]
+
+[[repos.hooks]]
+id = "check-merge-conflict"
+
+[[repos.hooks]]
+id = "check-toml"
+
+[[repos.hooks]]
+id = "check-yaml"
+
+[[repos.hooks]]
+id = "debug-statements"
+
+[[repos.hooks]]
+id = "detect-private-key"
+
+[[repos.hooks]]
+id = "end-of-file-fixer"
+
+[[repos.hooks]]
+id = "pretty-format-json"
+args = ["--autofix", "--indent=2", "--no-ensure-ascii"]
+
+[[repos.hooks]]
+id = "trailing-whitespace"
 
 [[repos]]
-repo = "https://github.com/pre-commit/mirrors-mypy"
-rev = "v1.15.0"
-hooks = [
-  {
-    id = "mypy",
-    files = "^matrix_webhook_bridge/",
-    additional_dependencies = [
-      "types-PyYAML",
-      "types-jsonschema"
-    ]
-  }
-]
+repo = "https://github.com/astral-sh/ruff-pre-commit"
+rev = "v0.16.4"
+
+[[repos.hooks]]
+id = "ruff-check"
+
+[[repos.hooks]]
+id = "ruff-format"
+
+[[repos]]
+repo = "https://github.com/astral-sh/ty-pre-commit"
+rev = "v0.0.74"
+
+[[repos.hooks]]
+id = "ty"
 
 [[repos]]
 repo = "https://github.com/adrienverge/yamllint.git"
 rev = "v1.29.0"
-hooks = [
-  {
-    id = "yamllint",
-    args = [
-      "--strict",
-      "--config-file=.yamllint.yml"
-    ]
-  }
-]
+
+[[repos.hooks]]
+id = "yamllint"
+args = ["--strict", "--config-file=.yamllint.yml"]
 
 [[repos]]
 repo = "https://github.com/compilerla/conventional-pre-commit"
 rev = "v4.3.0"
-hooks = [
-  {
-    id = "conventional-pre-commit",
-    stages = ["commit-msg"],
-    args = ["--verbose"]
-  }
-]
+
+[[repos.hooks]]
+id = "conventional-pre-commit"
+stages = ["commit-msg"]
+args = ["--verbose"]
 
 [[repos]]
 repo = "https://github.com/DavidAnson/markdownlint-cli2"
 rev = "v0.20.0"
-hooks = [
-  {
-    id = "markdownlint-cli2",
-    args = ["--fix"],
-    files = '\.md$',
-    language_version = "system"
-  }
-]
+
+[[repos.hooks]]
+id = "markdownlint-cli2"
+args = ["--fix"]
+files = '\.md$'
+language_version = "system"
 
 [[repos]]
 repo = "https://github.com/hadolint/hadolint"
 rev = "v2.12.0"
-hooks = [
-  {
-    id = "hadolint-docker",
-    args = [
-      "--config",
-      ".hadolint.yaml"
-    ]
-  }
-]
+
+[[repos.hooks]]
+id = "hadolint-docker"
+args = ["--config", ".hadolint.yaml"]
 
 [[repos]]
 repo = "https://github.com/koalaman/shellcheck-precommit"
 rev = "v0.10.0"
-hooks = [
-  { id = "shellcheck" }
-]
+
+[[repos.hooks]]
+id = "shellcheck"
 
 [[repos]]
 repo = "https://github.com/PyCQA/bandit"
 rev = "1.8.3"
-hooks = [
-  {
-    id = "bandit",
-    args = [
-      "-c",
-      "pyproject.toml"
-    ]
-  }
-]
+
+[[repos.hooks]]
+id = "bandit"
+args = ["-c", "pyproject.toml"]
 
 [[repos]]
 repo = "https://github.com/pypa/pip-audit"
 rev = "v2.8.0"
-hooks = [
-  {
-    id = "pip-audit",
-    args = [
-      "--ignore-vuln",
-      "PYSEC-2026-196"
-    ]
-  }
-]
+
+[[repos.hooks]]
+id = "pip-audit"
+args = ["--ignore-vuln", "PYSEC-2026-196"]
+# PYSEC-2026-196: vulnerability in pip itself (<=26.1.1), not a project
+# dependency. Remove once the hook env picks up pip 26.1.2+.
 
 [[repos]]
 repo = "https://github.com/rhysd/actionlint"
 rev = "v1.7.7"
-hooks = [
-  {
-    id = "actionlint",
-    files = '\.github/workflows/.*\.yml$'
-  }
-]
+
+[[repos.hooks]]
+id = "actionlint"
+files = '\.github/workflows/.*\.yml$'
 
 [[repos]]
 repo = "https://github.com/scop/pre-commit-shfmt"
 rev = "v3.12.0-2"
-hooks = [
-  {
-    id = "shfmt",
-    args = [
-      "-i",
-      "2",
-      "-ci",
-      "-s",
-      "-bn"
-    ],
-    files = '\.sh$'
-  }
-]
+
+[[repos.hooks]]
+id = "shfmt"
+args = ["-i", "2", "-ci", "-s", "-bn"]
+files = '\.sh$'
 
 [[repos]]
 repo = "https://github.com/codespell-project/codespell"
 rev = "v2.2.6"
-hooks = [
-  {
-    id = "codespell",
-    args = ["--write-changes"]
-  }
-]
+
+[[repos.hooks]]
+id = "codespell"
+args = ["--write-changes"]
 
 [[repos]]
 repo = "https://github.com/Yelp/detect-secrets"
 rev = "v1.5.0"
-hooks = [
-  {
-    id = "detect-secrets",
-    args = [
-      "--baseline",
-      ".secrets.baseline"
-    ]
-  }
-]
+
+[[repos.hooks]]
+id = "detect-secrets"
+args = ["--baseline", ".secrets.baseline"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,7 @@ test = ["pytest>=8", "httpx>=0.27"]
 [tool.bandit]
 exclude_dirs = ["tests"]
 
-[tool.mypy]
-python_version = "3.11"
-ignore_missing_imports = true
-warn_return_any = true
-warn_unused_ignores = true
-warn_redundant_casts = true
+[tool.ty.src]
 exclude = ["integrations/", "tests/"]
 
 [tool.ruff]

--- a/tests/test_formatter_alertmanager.py
+++ b/tests/test_formatter_alertmanager.py
@@ -53,9 +53,9 @@ def test_format_alertmanager_escapes_html_and_href_values():
     assert '<b onclick="alert(2)">details</b>' not in html
     assert '<time onmouseover="alert(3)">now</time>' not in html
     assert 'onclick="alert' not in html
-    assert '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;' in html
-    assert '&lt;b onclick=&quot;alert(2)&quot;&gt;details&lt;/b&gt;' in html
-    assert '&lt;time onmouseover=&quot;alert(3)&quot;&gt;now&lt;/time&gt;' in html
+    assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in html
+    assert "&lt;b onclick=&quot;alert(2)&quot;&gt;details&lt;/b&gt;" in html
+    assert "&lt;time onmouseover=&quot;alert(3)&quot;&gt;now&lt;/time&gt;" in html
     href_match = re.search(r'<a href="([^"]*)">', html)
     assert href_match is not None
     assert href_match.group(1) == (

--- a/tests/test_notify_performance.py
+++ b/tests/test_notify_performance.py
@@ -8,6 +8,7 @@ Checked the test can fail: passing headers={"Connection": "close"} in
 _do_request (forcing a fresh connection every time) turns the 1 connect()
 below into 20, past MAX_CONNECTS.
 """
+
 import threading
 from cProfile import Profile
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer


### PR DESCRIPTION
- add `astral-sh/ruff-pre-commit` (`ruff-check`, `ruff-format`) and `astral-sh/ty-pre-commit`, drop `mirrors-mypy` from `prek.toml` and `[tool.mypy]` from `pyproject.toml`
- rewrite `prek.toml` from multiline inline tables to `[[repos.hooks]]` array-of-tables for standard TOML tooling
- apply `ruff format` repo-wide (quote style, blank lines)

Closes #100