### PR TITLE
chore: add renovate config

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -147,3 +147,10 @@ rev = "v1.5.0"
 [[repos.hooks]]
 id = "detect-secrets"
 args = ["--baseline", ".secrets.baseline"]
+
+[[repos]]
+repo = "https://github.com/renovatebot/pre-commit-hooks"
+rev = "44.39.2"
+
+[[repos.hooks]]
+id = "renovate-config-validator"

--- a/renovate.json
+++ b/renovate.json
@@ -16,5 +16,13 @@
   "extends": [
     "config:recommended",
     "schedule:weekly"
-  ]
+  ],
+  "labels": [
+    "changelog:skip"
+  ],
+  "vulnerabilityAlerts": {
+    "labels": [
+      "changelog:security"
+    ]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "github-tags",
+      "fileMatch": [
+        "^prek\\.toml$"
+      ],
+      "matchStrings": [
+        "repo\\s*=\\s*\"(?<depName>[^\"]+)\"\\s*\\n(?:.*\\n)*?rev\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "packageNameTemplate": "{{{replace 'https://github.com/' '' depName}}}"
+    }
+  ],
+  "extends": [
+    "config:recommended"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
     }
   ],
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "schedule:weekly"
   ]
 }


### PR DESCRIPTION
- Add `renovate.json` extending `config:recommended` (covers uv/pyproject, Docker base image, GH Actions)
- Custom regex manager for `prek.toml` hook revs — native prek support isn't merged upstream yet
- Add `renovate-config-validator` prek hook to catch bad renovate config on commit

Closes #101