### PR TITLE
fix(renovate): strip .git suffix from custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,9 +8,8 @@
         "^prek\\.toml$"
       ],
       "matchStrings": [
-        "repo\\s*=\\s*\"(?<depName>[^\"]+)\"\\s*\\n(?:.*\\n)*?rev\\s*=\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "packageNameTemplate": "{{{replace 'https://github.com/' '' depName}}}"
+        "repo\\s*=\\s*\"https://github\\.com/(?<depName>[^\"]+?)(?:\\.git)?\"\\s*\\n(?:.*\\n)*?rev\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ]
     }
   ],
   "extends": [


### PR DESCRIPTION
- Fix custom regex manager in `renovate.json` — depName kept trailing `.git` for repos pinned as `https://github.com/owner/repo.git`
- Broke lookup for `adrienverge/yamllint.git` in `prek.toml` (Mend reported "no-result")
- Regex now strips `.git` at capture time, no separate `packageNameTemplate` needed