### PR TITLE
fix(renovate): disable dependency dashboard approval gate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
       ]
     }
   ],
+  "dependencyDashboardApproval": false,
   "extends": [
     "config:recommended",
     "schedule:weekly"


### PR DESCRIPTION
- Mend's hosted dashboard showed pending updates behind a manual "Approve" step
- `renovate.json` never set `dependencyDashboardApproval` — must be a platform/org-level default
- Set it explicitly to `false`; repo config overrides inherited presets