### PR TITLE
chore(renovate): group all dependency updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,15 @@
   "labels": [
     "changelog:skip"
   ],
+  "packageRules": [
+    {
+      "groupName": "all dependencies",
+      "matchPackageNames": [
+        "*"
+      ],
+      "separateMajorMinor": false
+    }
+  ],
   "vulnerabilityAlerts": {
     "labels": [
       "changelog:security"


### PR DESCRIPTION
- Group all Renovate-managed dependencies (actions, docker, python, pre-commit) into one weekly PR
- `separateMajorMinor: false` so major bumps land in the same PR too, not split out
- Cuts CI runs for this repo's limited free-plan minutes